### PR TITLE
Chore - Updated `cassandra-unit` to latest version (3.0.0.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.cassandraunit</groupId>
             <artifactId>cassandra-unit</artifactId>
-            <version>2.1.9.2</version>
+            <version>3.0.0.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Updated `cassandra-unit` to latest version, which contains the latest embedded Cassandra and DataStax Cassandra driver version.
