### PR TITLE
Allow a configurable prefix to be prepended to `cassandra_migration_version*` table names

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ keyspaceConfig.getClusterConfig().setPassword(CASSANDRA_PASSWORD);
 CassandraMigration cm = new CassandraMigration();
 cm.setLocations(scriptsLocations);
 cm.setKeyspaceConfig(keyspaceConfig);
+cm.setTablePrefix("my_app_");
 cm.migrate();
 ```
 
@@ -117,6 +118,7 @@ cm.migrate();
 ``` shell
 java -jar \
 -Dcassandra.migration.scripts.locations=filesystem:target/test-classes/migration/integ \
+-Dcassandra.migration.table.prefix=another_app_ \
 -Dcassandra.migration.cluster.contactpoints=localhost \
 -Dcassandra.migration.cluster.port=9147 \
 -Dcassandra.migration.cluster.username=cassandra \
@@ -139,6 +141,7 @@ Migration:
  * `cassandra.migration.scripts.encoding`: The encoding of CQL scripts (default=UTF-8)
  * `cassandra.migration.scripts.allowoutoforder`: Allow out of order migration (default=false)
  * `cassandra.migration.version.target`: The target version. Migrations with a higher version number will be ignored. (default=latest)
+ * `cassandra.migration.table.prefix`: The prefix to be prepended to `cassandra_migration_version*` table names.
 
 Cluster:
  * `cassandra.migration.cluster.contactpoints`: Comma separated values of node IP addresses (default=localhost)

--- a/src/main/java/com/builtamont/cassandra/migration/CassandraMigration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/CassandraMigration.kt
@@ -323,7 +323,7 @@ class CassandraMigration : CassandraMigrationConfiguration {
     }
 
     private fun migrationTableName(): String{
-        return tablePrefix + MigrationVersion.CURRENT.table
+        return tablePrefix.orEmpty() + MigrationVersion.CURRENT.table
     }
 
     /**

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/CassandraMigrationConfiguration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/CassandraMigrationConfiguration.kt
@@ -226,4 +226,15 @@ interface CassandraMigrationConfiguration {
      */
     val locations: Array<String>
 
+    /**
+     * Retrieves the migration table prefix.
+     *
+     * The prefix will be prepended to `cassandra_migration_version*` table names.
+     *
+     * By providing the prefix, multiple applications can have their own migration tables tracking the migration of their
+     * own cassandra database assets without interfering with each other.
+     *
+     * @return the prefix to be prepended to `cassandra_migration_version*` table names
+     */
+    val tablePrefix: String
 }

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
@@ -38,6 +38,11 @@ enum class ConfigurationProperty(val namespace: String, val description: String)
             "Locations of the migration scripts in CSV format"
     ),
 
+    TABLE_PREFIX(
+            "cassandra.migration.table.prefix",
+            "Prefix to be prepended to cassandra_migration_version* table names"
+    ),
+
     ALLOW_OUT_OF_ORDER(
             "cassandra.migration.scripts.allowoutoforder",
             "Allow out of order migration"

--- a/src/test/java/com/builtamont/cassandra/migration/CassandraMigrationIT.java
+++ b/src/test/java/com/builtamont/cassandra/migration/CassandraMigrationIT.java
@@ -248,6 +248,20 @@ public class CassandraMigrationIT extends BaseIT {
     }
 
     @Test
+    public void testBaseLineWithTablePrefix() {
+        String[] scriptsLocations = {"migration/integ", "migration/integ/java"};
+        CassandraMigration cm = new CassandraMigration();
+        cm.setLocations(scriptsLocations);
+        cm.setKeyspaceConfig(getKeyspace());
+        cm.setTablePrefix("test1_");
+        cm.baseline();
+
+        SchemaVersionDAO schemaVersionDAO = new SchemaVersionDAO(getSession(), getKeyspace(), cm.getTablePrefix() + MigrationVersion.Companion.getCURRENT().getTable());
+        AppliedMigration baselineMarker = schemaVersionDAO.getBaselineMarker();
+        assertThat(baselineMarker.getVersion(), is(MigrationVersion.Companion.fromVersion("1")));
+    }
+
+    @Test
     public void testBaseLineWithSession() {
         String[] scriptsLocations = {"migration/integ", "migration/integ/java"};
         Session session = getSession();
@@ -257,6 +271,21 @@ public class CassandraMigrationIT extends BaseIT {
         cm.baseline(session);
 
         SchemaVersionDAO schemaVersionDAO = new SchemaVersionDAO(getSession(), getKeyspace(), MigrationVersion.Companion.getCURRENT().getTable());
+        AppliedMigration baselineMarker = schemaVersionDAO.getBaselineMarker();
+        assertThat(baselineMarker.getVersion(), is(MigrationVersion.Companion.fromVersion("1")));
+    }
+
+    @Test
+    public void testBaseLineWithSessionAndTablePrefix() {
+        String[] scriptsLocations = {"migration/integ", "migration/integ/java"};
+        Session session = getSession();
+        CassandraMigration cm = new CassandraMigration();
+        cm.setLocations(scriptsLocations);
+        cm.setKeyspaceConfig(getKeyspace());
+        cm.setTablePrefix("test2_");
+        cm.baseline(session);
+
+        SchemaVersionDAO schemaVersionDAO = new SchemaVersionDAO(getSession(), getKeyspace(), cm.getTablePrefix() + MigrationVersion.Companion.getCURRENT().getTable());
         AppliedMigration baselineMarker = schemaVersionDAO.getBaselineMarker();
         assertThat(baselineMarker.getVersion(), is(MigrationVersion.Companion.fromVersion("1")));
     }


### PR DESCRIPTION
## Summary

Completes feature #16 

Now the migration table name prefix can be set by any of these:
- In code: `cm.setTablePrefix("my_app_");`
- As command line argument: `-Dcassandra.migration.table.prefix=another_app_`

The name `tablePrefix` follows the name `table` of Flyway (https://flywaydb.org/documentation/commandline/info)

<hr>
## Pull Request (PR) Checklist
### Documentation
- [x] Documentation in `README.md` or Wiki updated
### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [ ] Completed all relevant `TODO`s, or call them out in the PR comments
### Tests
- [x] All tests passes
