### PR TITLE
Chore - Configurable integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 #   limitations under the License.
 ###
 
-# Created by https://www.gitignore.io/api/windows,osx,linux,intellij,eclipse,netbeans,maven
+# Created by https://www.gitignore.io/api/windows,osx,linux,intellij,eclipse,netbeans,maven,vagrant
 
 ### Windows ###
 # Windows image file caches
@@ -191,6 +191,10 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+
+
+### Vagrant ###
+.vagrant/
 
 
 ### Others ###

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ services:
 matrix:
   include:
     - jdk: openjdk7
-      script: mvn test
+      script: ./scripts/verify.sh
     - jdk: oraclejdk7
-      script: mvn test
+      script: ./scripts/verify.sh
     - jdk: oraclejdk8
-      script: mvn test
+      script: ./scripts/verify.sh
     - jdk: oraclejdk8
-      script: mvn verify
+      script: ./scripts/verify.sh
     - jdk: oraclejdk8
-      script: mvn verify -Dcassandra.migration.cluster.contactpoints=127.0.0.1 -Dcassandra.migration.cluster.port=9042 -Dcassandra.migration.disable_embedded=true
+      script: ./scripts/verify-embedded.sh
 deploy:
   provider: script
   script: ./scripts/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,24 @@ matrix:
       services: cassandra
       script: ./scripts/verify.sh
     - jdk: openjdk7
+      sudo: required
+      dist: trusty
       before_install: ./scripts/configure-apache-cassandra.sh
       script: ./scripts/verify.sh
     - jdk: oraclejdk7
       services: cassandra
       script: ./scripts/verify.sh
     - jdk: oraclejdk7
+      sudo: required
+      dist: trusty
       before_install: ./scripts/configure-apache-cassandra.sh
       script: ./scripts/verify.sh
     - jdk: oraclejdk8
       services: cassandra
       script: ./scripts/verify.sh
     - jdk: oraclejdk8
+      sudo: required
+      dist: trusty
       before_install: ./scripts/configure-apache-cassandra.sh
       script: ./scripts/verify.sh
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,25 @@ env:
   global:
     - secure: "q+fkZBCN8ET5RrgaG4RGt1t1aSjsL6LN6BSt/Yvx2H5a2DtGmNA/A/gcAEnKlyv0BgXAcrzAzCCIgXvt2P4om5DcBU/yOTEga+/46r7+iVnmfQGcW81NHQA1rlIYvuBqXGDo9yo1B3eRr8vTj3fzEE3K8jjchHQUlgRdUum3DNKeZwACodV2fpj9ZslyoX4HRpWg3ctqvB0R7/4NwtXnXrOw8hHDF8OrQK3JiCxAoZnA16/Fwc0d8yN4Or10N1XiWbNdLFek+Y3nVTdGRUZjsqp/VhvgIwzmtnuiCeF2iuMCpYy6C9SAFG4Tyn5VLmFzEqXMrbxuMBp8c2GCcFQb0jxEiWKsT0Nufqc1pYlUSl2S12D8yokEo5H9/NcH/2p2b5zqzcWzFe1c5YEn0Ktj8d/01GDYfkuPyoQ0UmjC6h68iozk5mogPT0t7eUf7i0wll72v4kGB2xOK3VY+53LA7DS+f/0HeDi47tXgPkA8bg2dGZTTD+JHXcqyMTt9Ey96a42cauLQ4PGfujc6fPJUw31sxx2IURj1USdxut/a5PEa+LL+xGrKKgOW4GMUwjrYMnLf9e3Y/uR4EoHmYYwsoNtD0g6bEt7C83JZrQd5Sp3mN6gEU0sjp2/iBPqS+tB3z6eRUur8ctnk6EC82WHmRwZHeoKLVOktAPCKumBnWY="
     - secure: "04af3/9b67O5xd1U8GDhCqRQedHM3RP5HokdsOwAe8vN3EyyyKWXQafBkKsPvmDh5Uu/CYQppOYS4pQxB9ikweTfj34DbyyxpqJmjYE4KFvdQuFd0msyXhLCg6xfvS4KO6zjUQ8/c3rNQap4hx/icQ50/NES4rkUkxIZ/VKQ4jPXcBzPegEC6Le50Vw2tR8FT4erdNuABnGf1WnWGUUa3i6xdQQPyw8kdTIun08HxE6M9F+JJRH8jH3b7KizQhGdACAk4fnCOmFSgu7pm6ACXRJYqAfg055i5mr77yZXfeUIcIY3l45uY1uR8sxEbLUE/KwwlLGLVZWDI4xU6JIGisbrmMce+vz6YKUT9gHF3iAEJ5e4N18nJcRyHVrqcuRzv5Py0rFPZ70dr7aW/tk0JrTz6+FZ4FNIOdvIQe4qWy2TVns0EkERdtYGTdsigWfa/sKF/P5+/2foUOlnR06p55NHpIjaHRKy/XFVV1gyURUlRUGExVoIMX21bAMxGYMFMH7LfddRsly028lXwibRMkQGBeyVRYKQmqJvN3mTPbuAWmZZdaVpqn1jkgETlT6/qz43zv9y8jAOzZ22SeHEXe3NiexChqkAJWIH3cBYshMhy8H1fmYAIVYHvI+BPsbi+qDYSnAlAUDqoLWXPAvWUX89dAIXYRNcKplzpFsjWvM="
-services:
-  - cassandra
 matrix:
   include:
     - jdk: openjdk7
+      services: cassandra
+      script: ./scripts/verify.sh
+    - jdk: openjdk7
+      before_install: ./scripts/configure-apache-cassandra.sh
       script: ./scripts/verify.sh
     - jdk: oraclejdk7
+      services: cassandra
+      script: ./scripts/verify.sh
+    - jdk: oraclejdk7
+      before_install: ./scripts/configure-apache-cassandra.sh
       script: ./scripts/verify.sh
     - jdk: oraclejdk8
+      services: cassandra
       script: ./scripts/verify.sh
     - jdk: oraclejdk8
+      before_install: ./scripts/configure-apache-cassandra.sh
       script: ./scripts/verify.sh
     - jdk: oraclejdk8
       script: ./scripts/verify-embedded.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,8 @@ matrix:
     - jdk: openjdk7
       services: cassandra
       script: ./scripts/verify.sh
-    - jdk: openjdk7
-      sudo: required
-      dist: trusty
-      before_install: ./scripts/configure-apache-cassandra.sh
-      script: ./scripts/verify.sh
     - jdk: oraclejdk7
       services: cassandra
-      script: ./scripts/verify.sh
-    - jdk: oraclejdk7
-      sudo: required
-      dist: trusty
-      before_install: ./scripts/configure-apache-cassandra.sh
       script: ./scripts/verify.sh
     - jdk: oraclejdk8
       services: cassandra

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ env:
   global:
     - secure: "q+fkZBCN8ET5RrgaG4RGt1t1aSjsL6LN6BSt/Yvx2H5a2DtGmNA/A/gcAEnKlyv0BgXAcrzAzCCIgXvt2P4om5DcBU/yOTEga+/46r7+iVnmfQGcW81NHQA1rlIYvuBqXGDo9yo1B3eRr8vTj3fzEE3K8jjchHQUlgRdUum3DNKeZwACodV2fpj9ZslyoX4HRpWg3ctqvB0R7/4NwtXnXrOw8hHDF8OrQK3JiCxAoZnA16/Fwc0d8yN4Or10N1XiWbNdLFek+Y3nVTdGRUZjsqp/VhvgIwzmtnuiCeF2iuMCpYy6C9SAFG4Tyn5VLmFzEqXMrbxuMBp8c2GCcFQb0jxEiWKsT0Nufqc1pYlUSl2S12D8yokEo5H9/NcH/2p2b5zqzcWzFe1c5YEn0Ktj8d/01GDYfkuPyoQ0UmjC6h68iozk5mogPT0t7eUf7i0wll72v4kGB2xOK3VY+53LA7DS+f/0HeDi47tXgPkA8bg2dGZTTD+JHXcqyMTt9Ey96a42cauLQ4PGfujc6fPJUw31sxx2IURj1USdxut/a5PEa+LL+xGrKKgOW4GMUwjrYMnLf9e3Y/uR4EoHmYYwsoNtD0g6bEt7C83JZrQd5Sp3mN6gEU0sjp2/iBPqS+tB3z6eRUur8ctnk6EC82WHmRwZHeoKLVOktAPCKumBnWY="
     - secure: "04af3/9b67O5xd1U8GDhCqRQedHM3RP5HokdsOwAe8vN3EyyyKWXQafBkKsPvmDh5Uu/CYQppOYS4pQxB9ikweTfj34DbyyxpqJmjYE4KFvdQuFd0msyXhLCg6xfvS4KO6zjUQ8/c3rNQap4hx/icQ50/NES4rkUkxIZ/VKQ4jPXcBzPegEC6Le50Vw2tR8FT4erdNuABnGf1WnWGUUa3i6xdQQPyw8kdTIun08HxE6M9F+JJRH8jH3b7KizQhGdACAk4fnCOmFSgu7pm6ACXRJYqAfg055i5mr77yZXfeUIcIY3l45uY1uR8sxEbLUE/KwwlLGLVZWDI4xU6JIGisbrmMce+vz6YKUT9gHF3iAEJ5e4N18nJcRyHVrqcuRzv5Py0rFPZ70dr7aW/tk0JrTz6+FZ4FNIOdvIQe4qWy2TVns0EkERdtYGTdsigWfa/sKF/P5+/2foUOlnR06p55NHpIjaHRKy/XFVV1gyURUlRUGExVoIMX21bAMxGYMFMH7LfddRsly028lXwibRMkQGBeyVRYKQmqJvN3mTPbuAWmZZdaVpqn1jkgETlT6/qz43zv9y8jAOzZ22SeHEXe3NiexChqkAJWIH3cBYshMhy8H1fmYAIVYHvI+BPsbi+qDYSnAlAUDqoLWXPAvWUX89dAIXYRNcKplzpFsjWvM="
+services:
+  - cassandra
 matrix:
   include:
     - jdk: openjdk7
@@ -13,6 +15,8 @@ matrix:
       script: mvn test
     - jdk: oraclejdk8
       script: mvn verify
+    - jdk: oraclejdk8
+      script: mvn verify -Dcassandra.migration.cluster.contactpoints=127.0.0.1 -Dcassandra.migration.cluster.port=9042 -Dcassandra.migration.disable_embedded=true
 deploy:
   provider: script
   script: ./scripts/deploy.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is designed to work similar to Flyway, supporting plain CQL and Java-based mi
 Ensure the following prerequisites are met: 
 
  * **Java SDK 1.7+:**<br />The library is developed using Azul Zulu 1.8, and release-tested (Travis CI) with OpenJDK 1.7, Oracle JDK 1.7, and Oracle JDK 1.8
- * **Apache Cassandra 3.0.x:**<br />The library is release-tested (Travis CI) on embedded Cassandra, Apache Cassandra, and DataStax Enterprise Community Edition
+ * **Apache Cassandra 3.0.x:**<br />The library is release-tested (Travis CI) on embedded Cassandra, Apache Cassandra, and DataStax Enterprise Community Edition (on Oracle JDK 1.8)
  * **Pre-existing Keyspace:**<br />Cassandra's Keyspace should be managed outside the migration tool by sysadmins (e.g. tune replication factor, etc)
 
 Add the Sonatype Nexus OSS repo, and...
@@ -186,6 +186,14 @@ Run `mvn test` to run the unit tests.
 Run `mvn verify` to run the integration tests.
 
 ***NOTE:** The integration test might complain about some missing SIGAR binaries, this can be safely ignored. If you wish, you can download the missing binaries and set `java.library.path` parameter to point to the containing folder (e.g. `mvn verify -Djava.library.path=lib` where `lib` is the `/lib` folder relative to the project root).*
+
+### Travis CI Integration Test Matrix
+
+| Casandra Distribution         | OpenJDK 1.7 | Oracle JDK 1.7 | Oracle JDK 1.8 |
+| ----------------------------- |:-----------:|:--------------:|:--------------:|
+| Embedded Cassandra            |             |                | `YES`          |
+| Apache Cassandra 3.9          |             |                | `YES`          |
+| DataStax Enterprise Community | `YES`       | `YES`          | `YES`          |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is designed to work similar to Flyway, supporting plain CQL and Java-based mi
 Ensure the following prerequisites are met: 
 
  * **Java SDK 1.7+:**<br />The library is developed using Azul Zulu 1.8, and release-tested (Travis CI) with OpenJDK 1.7, Oracle JDK 1.7, and Oracle JDK 1.8
- * **Apache Cassandra 3.0.x:**<br />The library is currently tested using embedded Cassandra, testing with standalone Cassandra (DataStax Community Edition) is in the roadmap
+ * **Apache Cassandra 3.0.x:**<br />The library is release-tested (Travis CI) on embedded Cassandra, Apache Cassandra, and DataStax Enterprise Community Edition
  * **Pre-existing Keyspace:**<br />Cassandra's Keyspace should be managed outside the migration tool by sysadmins (e.g. tune replication factor, etc)
 
 Add the Sonatype Nexus OSS repo, and...
@@ -39,7 +39,7 @@ import this library as a dependency:
 </dependency>
 ```
 
-***NOTE:** Integration test in Travis CI is only run against Oracle JDK 1.8, due to embedded Cassandra's dependencies on JDK 1.8* 
+***NOTE:** A Vagrant script is provided to enable quick integration testing against different or older Cassandra distributions.* 
 
 ### Migration version table
 
@@ -217,7 +217,7 @@ https://github.com/builtamont/cassandra-migration/releases
 
  * ~~Replace `config.Cluster.java` and `config.Keyspace.java` to the one provided by DataStax Cassandra driver~~<br />*NOTE: The classes are merely configuration objects, and has been updated for clarity.*
  * ~~Add additional features from upstream open PRs~~<br />*DONE: as per 8 September 2016 PRs.*
- * Add standalone Cassandra (DataStax Community Edition) integration test
+ * ~~Add standalone Cassandra (DataStax Community Edition) integration test~~<br />*DONE: Uses Travis' provided DataStax Enterprise Community distribution.*
  
 ## Non-Critical Pending Actions
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,169 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+###
+# File     : Vagrantfile
+# License  :
+#   Original   - Copyright (c) 2016 Brian Cantoni
+#   Derivative - Copyright (c) 2016 Citadel Technology Solutions Pte Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Notes:
+#   - Original found at: https://github.com/bcantoni/vagrant-cassandra
+###
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+# Guest VM(s) cluster configuration
+# ~~~~~
+CFG_MEMSIZE  = ENV['CASS_MEM'] || "2048"            # Configured memory for each guest VM
+CFG_CPUCOUNT = ENV['CASS_CPU'] || "2"               # Configured CPU core for each guest VM
+CFG_IP       = ENV['CASS_IP']  || "192.168.10.10"   # Configured VM's IP address
+CFG_TZ       = "UTC"                                # Configured timezone, e.g.  US/Pacific, US/Eastern, UTC, Europe/Warsaw, etc.
+
+# VM host configuration
+# ~~~~~
+VAGRANTFILE_API_VERSION = "2"
+
+
+# -----------------------------------------------------------------------------
+# Provisioning Scripts
+# -----------------------------------------------------------------------------
+# Debian proxy client configuration
+# Note: Only if 'DEB_CACHE_HOST' is defined
+deb_cache_cmds = ""
+if ENV['DEB_CACHE_HOST']
+  deb_cache_host = ENV['DEB_CACHE_HOST']
+  deb_cache_cmds = <<CACHE
+apt-get install squid-deb-proxy-client -y
+echo 'Acquire::http::Proxy "#{deb_cache_host}";' | sudo tee /etc/apt/apt.conf.d/30autoproxy
+echo "Acquire::http::Proxy { debian.datastax.com DIRECT; };" | sudo tee -a /etc/apt/apt.conf.d/30autoproxy
+echo "Acquire::http::Proxy { ppa.launchpad.net DIRECT; };" | sudo tee -a /etc/apt/apt.conf.d/30autoproxy
+cat /etc/apt/apt.conf.d/30autoproxy
+CACHE
+end
+
+# OpenJDK provisioning script
+node_script = <<SCRIPT
+#!/bin/bash
+
+# Set timezone
+echo "#{CFG_TZ}" > /etc/timezone
+dpkg-reconfigure -f noninteractive tzdata
+
+#{deb_cache_cmds}
+
+# Install base packages
+echo "Task: Installing base packages"
+apt-get -qq update
+apt-get -qqy install vim curl zip unzip git python-pip
+
+# Install Java
+# ~~~~~
+# Note: Choose either OpenJDK or Azul Zulu
+echo "Task: Installing Java"
+
+## Add OpenJDK PPA repository, and
+## install Java (comment / uncomment desired version)
+#add-apt-repository ppa:openjdk-r/ppa
+#apt-get -qq update
+##apt-get -qqy install openjdk-7-jdk
+#apt-get -qqy install openjdk-8-jdk
+
+# Add Azul Zulu repository, and
+# install Java (comment / uncomment desired version)
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
+echo "deb http://repos.azulsystems.com/ubuntu stable main" >> /etc/apt/sources.list.d/zulu.list
+apt-get -qq update
+#apt-get -qqy install zulu-7=7.14.0.5
+apt-get -qqy install zulu-8=8.15.0.1
+
+echo "Info: Base VM provisioning complete"
+SCRIPT
+
+# DataStax Enterprise Community Edition provisioning script
+dsec_install_script = <<SCRIPT
+#!/bin/bash
+
+# Add DataStax repository (incl. repository key)
+echo "Task: Adding DataStax repository"
+echo "deb http://debian.datastax.com/community stable main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+curl -L https://debian.datastax.com/debian/repo_key | sudo apt-key add -
+apt-get -qq update
+
+# Install DataStax Enterprise Community Edition Cassandra distribution (incl. optional utilities)
+echo "Task: Installing DataStax Enterprise Community Edition"
+apt-get -qqy install dsc30
+apt-get -qqy install cassandra-tools
+
+echo "Info: DataStax Enterprise Community Edition provisioning complete"
+SCRIPT
+
+# DataStax Community 3.x configuration script
+dsec_configure_script = <<SCRIPT
+echo "Task: Configuring DataStax Community 3.x"
+service cassandra stop
+rm -rf /var/lib/cassandra/data/system/*
+sudo sed -i "s|cluster_name: 'Test Cluster'|cluster_name: 'Cassandra Migration'|" /etc/cassandra/cassandra.yaml
+sudo sed -i 's|seeds: "127.0.0.1"|seeds: "#{CFG_IP}"|' /etc/cassandra/cassandra.yaml
+sudo sed -i "s|listen_address: localhost|listen_address: #{CFG_IP}|" /etc/cassandra/cassandra.yaml
+sudo sed -i "s|start_rpc: false|start_rpc: true|" /etc/cassandra/cassandra.yaml
+sudo sed -i "s|rpc_address: localhost|rpc_address: #{CFG_IP}|" /etc/cassandra/cassandra.yaml
+service cassandra start
+
+echo "Info: DataStax Community 3.x configuration complete"
+SCRIPT
+
+
+
+# -----------------------------------------------------------------------------
+# Vagrant Script
+# -----------------------------------------------------------------------------
+# VM provisioning
+# ~~~~~
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Use `vagrant-cachier` to cache common packages and reduce time to provision boxes
+  if Vagrant.has_plugin?("vagrant-cachier")
+    # Configure cached packages to be shared between instances of the same base box.
+    # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+    config.cache.scope = :box
+  end
+
+  config.vm.define :cassandra do |node|
+    # Use Ubuntu 14.04 LTS (Trusty Tahr) image from Hashicorp repository
+    node.vm.box = "ubuntu/trusty64"
+
+    # VMware Fusion host-specific configuration
+    node.vm.provider "vmware_fusion" do |vm|
+      vm.vmx["memsize"] = CFG_MEMSIZE
+      vm.vmx["numvcpus"] = CFG_CPUCOUNT
+    end
+
+    # VirtualBox host-specific configuration
+    node.vm.provider :virtualbox do |vm|
+      vm.name = "cassandra"
+      vm.customize ["modifyvm", :id, "--memory", CFG_MEMSIZE]
+      vm.customize ["modifyvm", :id, "--cpus"  , CFG_CPUCOUNT]
+    end
+
+    # Configure guest VM IP address
+    node.vm.network :private_network, ip: CFG_IP
+
+    node.vm.hostname = "cassandra"
+    node.vm.provision :shell, :inline => node_script
+    node.vm.provision :shell, :inline => dsec_install_script
+    node.vm.provision :shell, :inline => dsec_configure_script
+  end
+end

--- a/scripts/configure-apache-cassandra.sh
+++ b/scripts/configure-apache-cassandra.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+###
+# File     : configure_apache-cassandra.sh
+# License  :
+#   Copyright (c) 2016 Citadel Technology Solutions Pte Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+###
+
+sudo rm -rf /var/lib/cassandra/*
+wget http://www.us.apache.org/dist/cassandra/3.9/apache-cassandra-3.9-bin.tar.gz && tar -xvzf apache-cassandra-3.9-bin.tar.gz && sudo sh apache-cassandra-3.9/bin/cassandra

--- a/scripts/configure-apache-cassandra.sh
+++ b/scripts/configure-apache-cassandra.sh
@@ -19,4 +19,6 @@
 ###
 
 sudo rm -rf /var/lib/cassandra/*
-wget http://www.us.apache.org/dist/cassandra/3.9/apache-cassandra-3.9-bin.tar.gz && tar -xvzf apache-cassandra-3.9-bin.tar.gz && sudo sh apache-cassandra-3.9/bin/cassandra
+wget http://www.us.apache.org/dist/cassandra/3.9/apache-cassandra-3.9-bin.tar.gz
+tar -xvzf apache-cassandra-3.9-bin.tar.gz
+sudo sh apache-cassandra-3.9/bin/cassandra -R

--- a/scripts/verify-embedded.sh
+++ b/scripts/verify-embedded.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+###
+# File     : verify-embedded.sh
+# License  :
+#   Copyright (c) 2016 Citadel Technology Solutions Pte Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+###
+
+mvn verify

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+###
+# File     : verify.sh
+# License  :
+#   Copyright (c) 2016 Citadel Technology Solutions Pte Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+###
+
+mvn verify -Dcassandra.migration.cluster.contactpoints=127.0.0.1 -Dcassandra.migration.cluster.port=9042 -Dcassandra.migration.disable_embedded=true

--- a/src/test/java/com/builtamont/cassandra/migration/BaseIT.java
+++ b/src/test/java/com/builtamont/cassandra/migration/BaseIT.java
@@ -31,16 +31,36 @@ import org.junit.BeforeClass;
 
 public abstract class BaseIT {
 
-    public static final String CASSANDRA_KEYSPACE = "cassandra_migration_test";
-    public static final String CASSANDRA_CONTACT_POINT = "localhost";
-    public static final int CASSANDRA_PORT = 9147;
-    public static final String CASSANDRA_USERNAME = "cassandra";
-    public static final String CASSANDRA_PASSWORD = "cassandra";
+    public static final String CASSANDRA_KEYSPACE =
+            System.getProperty("cassandra.migration.keyspace.name") != null
+                    ? System.getProperty("cassandra.migration.keyspace.name")
+                    : "cassandra_migration_test";
+    public static final String CASSANDRA_CONTACT_POINT =
+            System.getProperty("cassandra.migration.cluster.contactpoints") != null
+                    ? System.getProperty("cassandra.migration.cluster.contactpoints")
+                    : "localhost";
+    public static final int CASSANDRA_PORT =
+            System.getProperty("cassandra.migration.cluster.port") != null
+                    ? Integer.parseInt(System.getProperty("cassandra.migration.cluster.port"))
+                    : 9147;
+    public static final String CASSANDRA_USERNAME =
+            System.getProperty("cassandra.migration.cluster.username") != null
+                    ? System.getProperty("cassandra.migration.cluster.username")
+                    : "cassandra";
+    public static final String CASSANDRA_PASSWORD =
+            System.getProperty("cassandra.migration.cluster.password") != null
+                    ? System.getProperty("cassandra.migration.cluster.password")
+                    : "cassandra";
+    public static final boolean DISABLE_EMBEDDED =
+            System.getProperty("cassandra.migration.disable_embedded") != null
+                    && Boolean.parseBoolean(System.getProperty("cassandra.migration.disable_embedded"));
 
     private Session session;
 
     @BeforeClass
     public static void beforeSuite() throws Exception {
+        if (DISABLE_EMBEDDED) return;
+
         EmbeddedCassandraServerHelper.startEmbeddedCassandra(
                 "cassandra-unit.yaml",
                 "target/embeddedCassandra",
@@ -49,6 +69,8 @@ public abstract class BaseIT {
 
     @AfterClass
     public static void afterSuite() {
+        if (DISABLE_EMBEDDED) return;
+
         EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
     }
 

--- a/src/test/java/com/builtamont/cassandra/migration/config/ClusterConfigurationTest.java
+++ b/src/test/java/com/builtamont/cassandra/migration/config/ClusterConfigurationTest.java
@@ -9,13 +9,27 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ClusterConfigurationTest {
+
     @Test
     public void shouldHaveDefaultConfigValues() {
         ClusterConfiguration clusterConfig = new ClusterConfiguration();
-        assertThat(clusterConfig.getContactpoints()[0], is("localhost"));
-        assertThat(clusterConfig.getPort(), is(9042));
-        assertThat(clusterConfig.getUsername(), is(nullValue()));
-        assertThat(clusterConfig.getPassword(), is(nullValue()));
+
+        // NOTE: Properties below are checked before any assertions, as integration tests allows these properties to be
+        //       overridden (thus assertion will fail).
+        //       It should be OK as Travis' test matrix should cover these different conditions (e.g. where System
+        //       properties are provided, and where default values should be used instead).
+
+        if (hasProperty("cassandra.migration.keyspace.name"))
+            assertThat(clusterConfig.getContactpoints()[0], is("localhost"));
+
+        if (hasProperty("cassandra.migration.cluster.port"))
+            assertThat(clusterConfig.getPort(), is(9042));
+
+        if (hasProperty("cassandra.migration.cluster.username"))
+            assertThat(clusterConfig.getUsername(), is(nullValue()));
+
+        if (hasProperty("cassandra.migration.cluster.password"))
+            assertThat(clusterConfig.getPassword(), is(nullValue()));
     }
 
     @Test
@@ -33,4 +47,15 @@ public class ClusterConfigurationTest {
         assertThat(clusterConfig.getUsername(), is("user"));
         assertThat(clusterConfig.getPassword(), is("pass"));
     }
+
+    /**
+     * Checks whether the given System property is defined.
+     *
+     * @param key The property key.
+     * @return True if the System property is defined.
+     */
+    private boolean hasProperty(String key) {
+        return System.getProperty(key) != null;
+    }
+
 }


### PR DESCRIPTION
## Summary

<!-- NOTE: Remove as necessary -->

Completes chore #22

Added support in integration test's `BaseIT` class to accept Java VM options. In addition, Travis CI integration test is expanded to cover more configuration (refer to 'Travis CI Integration Test Matrix' section in`README`).

<hr>
## Pull Request (PR) Checklist
### Documentation
- [x] Documentation in `README.md` or Wiki updated
### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments
### Tests
- [x] All tests passes
