### PR TITLE
Add support for Cassandra clusters with SSL enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Cluster:
  * `cassandra.migration.cluster.port`: CQL native transport port (default=9042)
  * `cassandra.migration.cluster.username`: Username for password authenticator (optional)
  * `cassandra.migration.cluster.password`: Password for password authenticator (optional)
+ * `cassandra.migration.cluster.truststore`: Path to truststore.jar for cassandra client SSL (optional)
+ * `cassandra.migration.cluster.truststore_password`: Password for truststore.jar (optional)
+ * `cassandra.migration.cluster.keystore`: Path to keystore.jar for cassandra client SSL with certificate authentication (optional)
+ * `cassandra.migration.cluster.keystore_password`: Password for keystore.jar (optional)
 
 Keyspace:
  * `cassandra.migration.keyspace.name`: Name of Cassandra keyspace (required)

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/ClusterConfiguration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/ClusterConfiguration.kt
@@ -18,6 +18,8 @@
  */
 package com.builtamont.cassandra.migration.api.configuration
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import com.builtamont.cassandra.migration.internal.util.StringUtils
 
 /**
@@ -52,6 +54,30 @@ class ClusterConfiguration {
       get set
 
     /**
+     * The path to the truststore.
+     */
+    var truststore: Path? = null
+      get set
+
+    /**
+     * The password for the truststore.
+     */
+    var truststorePassword: String? = null
+      get set
+
+    /**
+     * The path to the keystore.
+     */
+    var keystore: Path? = null
+        get set
+
+    /**
+     * The password for the keystore.
+     */
+    var keystorePassword: String? = null
+        get set
+
+    /**
      * ClusterConfiguration initialization.
      */
     init {
@@ -66,6 +92,18 @@ class ClusterConfiguration {
 
         val passwordProp = System.getProperty(ConfigurationProperty.PASSWORD.namespace)
         if (!passwordProp.isNullOrBlank()) this.password = passwordProp.trim()
+
+        val truststoreProp = System.getProperty(ConfigurationProperty.TRUSTSTORE.namespace)
+        if (!truststoreProp.isNullOrBlank()) this.truststore = Paths.get(truststoreProp.trim())
+
+        val truststorePasswordProp = System.getProperty(ConfigurationProperty.TRUSTSTORE_PASSWORD.namespace)
+        if (!truststorePasswordProp.isNullOrBlank()) this.truststorePassword = truststorePasswordProp.trim()
+
+        val keystoreProp = System.getProperty(ConfigurationProperty.KEYSTORE.namespace)
+        if (!keystoreProp.isNullOrBlank()) this.keystore = Paths.get(keystoreProp.trim())
+
+        val keystorePasswordProp = System.getProperty(ConfigurationProperty.KEYSTORE_PASSWORD.namespace)
+        if (!keystorePasswordProp.isNullOrBlank()) this.keystorePassword = keystorePasswordProp.trim()
     }
 
 }

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
@@ -77,6 +77,26 @@ enum class ConfigurationProperty(val namespace: String, val description: String)
             "Password for password authenticator"
     ),
 
+    TRUSTSTORE(
+            "cassandra.migration.cluster.truststore",
+            "Path to the truststore for client SSL"
+    ),
+
+    TRUSTSTORE_PASSWORD(
+            "cassandra.migration.cluster.truststore_password",
+            "Password for the truststore"
+    ),
+
+    KEYSTORE(
+            "cassandra.migration.cluster.keystore",
+            "Path to the keystore for client SSL certificate authentication"
+    ),
+
+    KEYSTORE_PASSWORD(
+            "cassandra.migration.cluster.keystore_password",
+            "Password for the keystore"
+    ),
+
     // Keyspace name configuration properties
     // ~~~~~~
     KEYSPACE_NAME(

--- a/src/test/java/com/builtamont/cassandra/migration/config/ClusterConfigurationTest.java
+++ b/src/test/java/com/builtamont/cassandra/migration/config/ClusterConfigurationTest.java
@@ -4,6 +4,8 @@ import com.builtamont.cassandra.migration.api.configuration.ClusterConfiguration
 import com.builtamont.cassandra.migration.api.configuration.ConfigurationProperty;
 import org.junit.Test;
 
+import java.nio.file.Paths;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -29,6 +31,18 @@ public class ClusterConfigurationTest {
 
         if (hasProperty(ConfigurationProperty.PASSWORD.getNamespace()))
             assertThat(clusterConfig.getPassword(), is(nullValue()));
+
+        if (hasProperty("cassandra.migration.cluster.truststore"))
+            assertThat(clusterConfig.getTruststore(), is(nullValue()));
+
+        if (hasProperty("cassandra.migration.cluster.truststorePassword"))
+            assertThat(clusterConfig.getTruststorePassword(), is(nullValue()));
+
+        if (hasProperty("cassandra.migration.cluster.keystore"))
+            assertThat(clusterConfig.getKeystore(), is(nullValue()));
+
+        if (hasProperty("cassandra.migration.cluster.keystorePassword"))
+            assertThat(clusterConfig.getKeystorePassword(), is(nullValue()));
     }
 
     @Test
@@ -37,6 +51,10 @@ public class ClusterConfigurationTest {
         System.setProperty(ConfigurationProperty.PORT.getNamespace(), "9144");
         System.setProperty(ConfigurationProperty.USERNAME.getNamespace(), "user");
         System.setProperty(ConfigurationProperty.PASSWORD.getNamespace(), "pass");
+        System.setProperty(ConfigurationProperty.TRUSTSTORE.getNamespace(), "truststore.jks");
+        System.setProperty(ConfigurationProperty.TRUSTSTORE_PASSWORD.getNamespace(), "pass");
+        System.setProperty(ConfigurationProperty.KEYSTORE.getNamespace(), "keystore.jks");
+        System.setProperty(ConfigurationProperty.KEYSTORE_PASSWORD.getNamespace(), "pass");
 
         ClusterConfiguration clusterConfig = new ClusterConfiguration();
         assertThat(clusterConfig.getContactpoints()[0], is("192.168.0.1"));
@@ -45,6 +63,10 @@ public class ClusterConfigurationTest {
         assertThat(clusterConfig.getPort(), is(9144));
         assertThat(clusterConfig.getUsername(), is("user"));
         assertThat(clusterConfig.getPassword(), is("pass"));
+        assertThat(clusterConfig.getTruststore(), is(Paths.get("truststore.jks")));
+        assertThat(clusterConfig.getTruststorePassword(), is("pass"));
+        assertThat(clusterConfig.getKeystore(), is(Paths.get("keystore.jks")));
+        assertThat(clusterConfig.getKeystorePassword(), is("pass"));
     }
 
     /**


### PR DESCRIPTION
## Summary

This change allows use with Cassandra clusters that have SSL enabled. It also supports SSL client auth if a keystore is supplied. I have updated tests, but there is no test that uses SSL because embedded Cassandra (cassandra-unit) does not support SSL connections. I have tested this manually, however.

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or Wiki updated

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes
