### PR TITLE
Allow baseline version & baseline description to be specified as config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Migration:
  * `cassandra.migration.scripts.allowoutoforder`: Allow out of order migration (default=false)
  * `cassandra.migration.version.target`: The target version. Migrations with a higher version number will be ignored. (default=latest)
  * `cassandra.migration.table.prefix`: The prefix to be prepended to `cassandra_migration_version*` table names.
+ * `cassandra.migration.baseline.version`: The version to apply for an existing schema when baseline is run.
+ * `cassandra.migration.baseline.description`: The description to apply for an existing schema when baseline is run
 
 Cluster:
  * `cassandra.migration.cluster.contactpoints`: Comma separated values of node IP addresses (default=localhost)

--- a/src/main/java/com/builtamont/cassandra/migration/CassandraMigration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/CassandraMigration.kt
@@ -128,6 +128,12 @@ class CassandraMigration : CassandraMigrationConfiguration {
 
         val allowOutOfOrderProp = System.getProperty(ConfigurationProperty.ALLOW_OUT_OF_ORDER.namespace)
         if (!allowOutOfOrderProp.isNullOrBlank()) allowOutOfOrder = allowOutOfOrderProp.toBoolean()
+
+        val baselineVersionProp = System.getProperty(ConfigurationProperty.BASELINE_VERSION.namespace)
+        if (!baselineVersionProp.isNullOrBlank()) baselineVersion = MigrationVersion.fromVersion(baselineVersionProp.trim())
+
+        val baselineDescriptionProp = System.getProperty(ConfigurationProperty.BASELINE_DESCRIPTION.namespace)
+        if (!baselineDescriptionProp.isNullOrBlank()) baselineDescription = baselineDescriptionProp.trim()
     }
 
     /**

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
@@ -48,6 +48,16 @@ enum class ConfigurationProperty(val namespace: String, val description: String)
             "Allow out of order migration"
     ),
 
+    BASELINE_VERSION(
+            "cassandra.migration.baseline.version",
+            "Version to apply for an existing schema when baseline is run"
+    ),
+
+    BASELINE_DESCRIPTION(
+            "cassandra.migration.baseline.description",
+            "Description to apply to an existing schema when baseline is run"
+    ),
+
     // Version target configuration properties
     // ~~~~~~
     TARGET_VERSION(

--- a/src/test/java/com/builtamont/cassandra/migration/internal/command/BaselineKIT.kt
+++ b/src/test/java/com/builtamont/cassandra/migration/internal/command/BaselineKIT.kt
@@ -50,6 +50,21 @@ class BaselineKIT : BaseKIT() {
                         baselineMarker.version shouldBe MigrationVersion.fromVersion("1")
                     }
 
+                    "for session and keyspace, version and description setup via configuration" {
+                        val scriptsLocations = arrayOf("migration/integ", "migration/integ/java")
+                        val cm = CassandraMigration()
+                        cm.locations = scriptsLocations
+                        cm.keyspaceConfig = getKeyspace()
+                        cm.baselineVersion = MigrationVersion.fromVersion("0.0.1")
+                        cm.baselineDescription = "Baseline test"
+                        cm.baseline()
+
+                        val schemaVersionDAO = SchemaVersionDAO(getSession(), getKeyspace(), MigrationVersion.CURRENT.table)
+                        val baselineMarker = schemaVersionDAO.baselineMarker
+
+                        baselineMarker.version shouldBe MigrationVersion.fromVersion("0.0.1")
+                    }
+
                     "for external session, but keyspace setup via configuration" {
                         val scriptsLocations = arrayOf("migration/integ", "migration/integ/java")
                         val session = getSession()
@@ -93,6 +108,22 @@ class BaselineKIT : BaseKIT() {
                         val baselineMarker = schemaVersionDAO.baselineMarker
 
                         baselineMarker.version shouldBe MigrationVersion.fromVersion("1")
+                    }
+
+                    "for session and keyspace, version and description setup via configuration" {
+                        val scriptsLocations = arrayOf("migration/integ", "migration/integ/java")
+                        val cm = CassandraMigration()
+                        cm.locations = scriptsLocations
+                        cm.keyspaceConfig = getKeyspace()
+                        cm.tablePrefix = "test1_"
+                        cm.baselineVersion = MigrationVersion.fromVersion("0.0.1")
+                        cm.baselineDescription = "Baseline test"
+                        cm.baseline()
+
+                        val schemaVersionDAO = SchemaVersionDAO(getSession(), getKeyspace(), cm.tablePrefix + MigrationVersion.CURRENT.table)
+                        val baselineMarker = schemaVersionDAO.baselineMarker
+
+                        baselineMarker.version shouldBe MigrationVersion.fromVersion("0.0.1")
                     }
 
                     "for external session, but keyspace setup via configuration" {
@@ -146,6 +177,22 @@ class BaselineKIT : BaseKIT() {
                         shouldThrow<CassandraMigrationException> { cm.baseline() }
                     }
 
+                    "for session and keyspace, version and description setup via configuration" {
+                        val scriptsLocations = arrayOf("migration/integ", "migration/integ/java")
+                        var cm = CassandraMigration()
+                        cm.locations = scriptsLocations
+                        cm.keyspaceConfig = getKeyspace()
+                        cm.migrate()
+
+                        cm = CassandraMigration()
+                        cm.locations = scriptsLocations
+                        cm.keyspaceConfig = getKeyspace()
+                        cm.baselineVersion = MigrationVersion.fromVersion("0.0.1")
+                        cm.baselineDescription = "Baseline test"
+
+                        shouldThrow<CassandraMigrationException> { cm.baseline() }
+                    }
+
                     "for external session, but keyspace setup via configuration" {
                         val scriptsLocations = arrayOf("migration/integ", "migration/integ/java")
                         val session = getSession()
@@ -190,6 +237,24 @@ class BaselineKIT : BaseKIT() {
                         cm.locations = scriptsLocations
                         cm.keyspaceConfig = getKeyspace()
                         cm.tablePrefix = "test1_"
+
+                        shouldThrow<CassandraMigrationException> { cm.baseline() }
+                    }
+
+                    "for session and keyspace, version and description setup via configuration" {
+                        val scriptsLocations = arrayOf("migration/integ", "migration/integ/java")
+                        var cm = CassandraMigration()
+                        cm.locations = scriptsLocations
+                        cm.keyspaceConfig = getKeyspace()
+                        cm.tablePrefix = "test1_"
+                        cm.migrate()
+
+                        cm = CassandraMigration()
+                        cm.locations = scriptsLocations
+                        cm.keyspaceConfig = getKeyspace()
+                        cm.tablePrefix = "test1_"
+                        cm.baselineVersion = MigrationVersion.fromVersion("0.0.1")
+                        cm.baselineDescription = "Baseline test"
 
                         shouldThrow<CassandraMigrationException> { cm.baseline() }
                     }


### PR DESCRIPTION
## Summary

Pretty simple change - this just allows baselineVersion and baselineDescription to be overridden by configuration properties

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or Wiki updated

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes