### PR TITLE
ConsistencyLevel is configurable

### DIFF
--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/KeyspaceConfiguration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/KeyspaceConfiguration.kt
@@ -18,6 +18,8 @@
  */
 package com.builtamont.cassandra.migration.api.configuration
 
+import com.datastax.driver.core.ConsistencyLevel
+
 /**
  * Keyspace configuration.
  */
@@ -32,6 +34,9 @@ class KeyspaceConfiguration {
      * Cassandra keyspace name.
      */
     var name: String? = null
+      get set
+
+    var consistency: ConsistencyLevel? = null
       get set
 
     /**

--- a/src/main/java/com/builtamont/cassandra/migration/internal/dbsupport/SchemaVersionDAO.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/internal/dbsupport/SchemaVersionDAO.kt
@@ -64,7 +64,20 @@ open class SchemaVersionDAO(private val session: Session, val keyspaceConfig: Ke
 
         // If running on a single host, don't force ConsistencyLevel.ALL
         val isClustered = session.cluster.metadata.allHosts.size > 1
-        this.consistencyLevel = if (isClustered) ConsistencyLevel.ALL else ConsistencyLevel.ONE
+
+        val clusterConsistencyLevel = if (isClustered) {
+            ConsistencyLevel.ALL
+        } else {
+            ConsistencyLevel.ONE
+        }
+
+        val noClusterConsistencyLevel = if (keyspaceConfig.consistency != null) {
+            keyspaceConfig.consistency
+        } else {
+            clusterConsistencyLevel
+        }
+
+        this.consistencyLevel = if (isClustered) clusterConsistencyLevel else noClusterConsistencyLevel!!
     }
 
     /**


### PR DESCRIPTION
## Summary

Completes feature #20 

Related tickets: #20 

Consistency level is configurable in KeyspaceConfiguration via setter. In case we are in clustered environment, consistency level is set to ALL, ONE otherwise. If consistency is not set in KeyspaceConfiguration, previously resolved consistency level is set, otherwise level in KeyspaceConfiguration is used.

<hr>

## Pull Request (PR) Checklist

### Code Review
- [x] Self code review

### Tests
- [x] All tests passes
