### PR TITLE
Set read timeout to 60 seconds when applying cql migrations

### DIFF
--- a/src/main/java/com/builtamont/cassandra/migration/internal/dbsupport/CqlScript.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/internal/dbsupport/CqlScript.kt
@@ -23,6 +23,7 @@ import com.builtamont.cassandra.migration.internal.util.StringUtils
 import com.builtamont.cassandra.migration.internal.util.logging.LogFactory
 import com.builtamont.cassandra.migration.internal.util.scanner.Resource
 import com.datastax.driver.core.Session
+import com.datastax.driver.core.SimpleStatement
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.Reader
@@ -75,7 +76,7 @@ class CqlScript {
     fun execute(session: Session) {
         cqlStatements.forEach {
             LOG.debug("Executing CQL: $it")
-            session.execute(it)
+            session.execute(SimpleStatement(it).setReadTimeoutMillis(60000))
         }
     }
 


### PR DESCRIPTION
## Summary

<!-- NOTE: Remove as necessary -->
Completes feature #*<GitHub issue number>* 
Completes chore #*<GitHub issue number>*
Fixes issue #*<GitHub issue number>*

Related tickets: #*<GitHub issue number>*

*<Write a short summary of your changes.>*

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or [Wiki](https://github.com/builtamont-oss/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/builtamont-oss/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes
