### PR TITLE
Feature - Configurable ConsistencyLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ String[] scriptsLocations = {"migration/cassandra"};
 
 KeyspaceConfiguration keyspaceConfig = new KeyspaceConfiguration();
 keyspaceConfig.setName(CASSANDRA_KEYSPACE);
+keyspaceConfig.setConsistency(ConsistencyLevel.QUORUM);
 keyspaceConfig.getClusterConfig().setContactpoints(CASSANDRA_CONTACT_POINT);
 keyspaceConfig.getClusterConfig().setPort(CASSANDRA_PORT);
 keyspaceConfig.getClusterConfig().setUsername(CASSANDRA_USERNAME);
@@ -129,6 +130,7 @@ java -jar \
 -Dcassandra.migration.cluster.username=cassandra \
 -Dcassandra.migration.cluster.password=cassandra \
 -Dcassandra.migration.keyspace.name=cassandra_migration_test \
+-Dcassandra.migration.keyspace.consistency=QUORUM \
 target/*-jar-with-dependencies.jar migrate
 ```
 
@@ -142,31 +144,32 @@ Logging level can be set by passing the following arguments:
 Options can be set either programmatically with API or via Java VM options.
 
 Migration:
- * `cassandra.migration.scripts.locations`: Locations of the migration scripts in CSV format. Scripts are scanned in the specified folder recursively. (default=db/migration)
- * `cassandra.migration.scripts.encoding`: The encoding of CQL scripts (default=UTF-8)
- * `cassandra.migration.scripts.allowoutoforder`: Allow out of order migration (default=false)
- * `cassandra.migration.version.target`: The target version. Migrations with a higher version number will be ignored. (default=latest)
+ * `cassandra.migration.scripts.locations`: Locations of the migration scripts in CSV format. Scripts are scanned in the specified folder recursively. (default=`db/migration`)
+ * `cassandra.migration.scripts.encoding`: The encoding of CQL scripts. (default=`UTF-8`)
+ * `cassandra.migration.scripts.allowoutoforder`: Allow out of order migration. (default=`false`)
+ * `cassandra.migration.version.target`: The target version. Migrations with a higher version number will be ignored. (default=`latest`)
  * `cassandra.migration.table.prefix`: The prefix to be prepended to `cassandra_migration_version*` table names.
  * `cassandra.migration.baseline.version`: The version to apply for an existing schema when baseline is run.
- * `cassandra.migration.baseline.description`: The description to apply for an existing schema when baseline is run
+ * `cassandra.migration.baseline.description`: The description to apply for an existing schema when baseline is run.
 
 Cluster:
- * `cassandra.migration.cluster.contactpoints`: Comma separated values of node IP addresses (default=localhost)
- * `cassandra.migration.cluster.port`: CQL native transport port (default=9042)
- * `cassandra.migration.cluster.username`: Username for password authenticator (optional)
- * `cassandra.migration.cluster.password`: Password for password authenticator (optional)
- * `cassandra.migration.cluster.truststore`: Path to truststore.jar for cassandra client SSL (optional)
- * `cassandra.migration.cluster.truststore_password`: Password for truststore.jar (optional)
- * `cassandra.migration.cluster.keystore`: Path to keystore.jar for cassandra client SSL with certificate authentication (optional)
- * `cassandra.migration.cluster.keystore_password`: Password for keystore.jar (optional)
+ * `cassandra.migration.cluster.contactpoints`: Comma separated values of node IP addresses. (default=`localhost`)
+ * `cassandra.migration.cluster.port`: CQL native transport port. (default=`9042`)
+ * `cassandra.migration.cluster.username`: Username for password authenticator. (optional)
+ * `cassandra.migration.cluster.password`: Password for password authenticator. (optional)
+ * `cassandra.migration.cluster.truststore`: Path to `truststore.jar` for Cassandra client SSL. (optional)
+ * `cassandra.migration.cluster.truststore_password`: Password for `truststore.jar`. (optional)
+ * `cassandra.migration.cluster.keystore`: Path to keystore.jar for Cassandra client SSL with certificate authentication. (optional)
+ * `cassandra.migration.cluster.keystore_password`: Password for `keystore.jar`. (optional)
 
 Keyspace:
- * `cassandra.migration.keyspace.name`: Name of Cassandra keyspace (required)
+ * `cassandra.migration.keyspace.name`: Name of Cassandra keyspace. (required)
+ * `cassandra.migration.keyspace.consistency`: Keyspace write consistency levels for migrations schema tracking. (optional)
 
 ### Cluster Coordination
 
- * Schema version tracking statements use `ConsistencyLevel.ALL`
- * Users should manage their own consistency level in the migration scripts
+ * Schema version tracking statements use `ConsistencyLevel.ALL` for clustered hosts, otherwise `ConsistencyLevel.ONE` for single host.
+ * Users should manage their own consistency level in the migration scripts.
 
 ### Limitations
 

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
@@ -112,6 +112,11 @@ enum class ConfigurationProperty(val namespace: String, val description: String)
     KEYSPACE_NAME(
             "cassandra.migration.keyspace.name",
             "Name of Cassandra keyspace"
+    ),
+
+    CONSISTENCY_LEVEL(
+            "cassandra.migration.keyspace.consistency",
+            "Keyspace write consistency levels for migrations schema tracking"
     )
 
 }

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/KeyspaceConfiguration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/KeyspaceConfiguration.kt
@@ -28,7 +28,7 @@ class KeyspaceConfiguration {
     /**
      * Cluster configuration.
      */
-    lateinit var clusterConfig: ClusterConfiguration
+    var clusterConfig: ClusterConfiguration = ClusterConfiguration()
 
     /**
      * Cassandra keyspace name.
@@ -36,6 +36,9 @@ class KeyspaceConfiguration {
     var name: String? = null
       get set
 
+    /**
+     * Keyspace consistency level.
+     */
     var consistency: ConsistencyLevel? = null
       get set
 
@@ -43,10 +46,11 @@ class KeyspaceConfiguration {
      * KeyspaceConfiguration initialization.
      */
     init {
-        clusterConfig = ClusterConfiguration()
-
         val keyspaceProp = System.getProperty(ConfigurationProperty.KEYSPACE_NAME.namespace)
         if (!keyspaceProp.isNullOrBlank()) this.name = keyspaceProp.trim()
+
+        val consistencyProp = System.getProperty(ConfigurationProperty.CONSISTENCY_LEVEL.namespace)
+        if (!consistencyProp.isNullOrBlank()) this.consistency = ConsistencyLevel.valueOf(consistencyProp.trim().toUpperCase())
     }
 
 }

--- a/src/main/java/com/builtamont/cassandra/migration/internal/dbsupport/SchemaVersionDAO.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/internal/dbsupport/SchemaVersionDAO.kt
@@ -64,20 +64,14 @@ open class SchemaVersionDAO(private val session: Session, val keyspaceConfig: Ke
 
         // If running on a single host, don't force ConsistencyLevel.ALL
         val isClustered = session.cluster.metadata.allHosts.size > 1
+        // Use configuration consistency if provided, otherwise default to `ALL` on cluster or `ONE` on single host
+        val consistencyDefined = keyspaceConfig.consistency != null
 
-        val clusterConsistencyLevel = if (isClustered) {
-            ConsistencyLevel.ALL
-        } else {
-            ConsistencyLevel.ONE
+        this.consistencyLevel = when {
+            consistencyDefined -> keyspaceConfig.consistency!!
+            isClustered        -> ConsistencyLevel.ALL
+            else               -> ConsistencyLevel.ONE
         }
-
-        val noClusterConsistencyLevel = if (keyspaceConfig.consistency != null) {
-            keyspaceConfig.consistency
-        } else {
-            clusterConsistencyLevel
-        }
-
-        this.consistencyLevel = if (isClustered) clusterConsistencyLevel else noClusterConsistencyLevel!!
     }
 
     /**

--- a/src/test/java/com/builtamont/cassandra/migration/config/KeyspaceConfigurationSpec.kt
+++ b/src/test/java/com/builtamont/cassandra/migration/config/KeyspaceConfigurationSpec.kt
@@ -21,6 +21,7 @@ package com.builtamont.cassandra.migration.config
 import com.builtamont.cassandra.migration.api.configuration.ClusterConfiguration
 import com.builtamont.cassandra.migration.api.configuration.ConfigurationProperty
 import com.builtamont.cassandra.migration.api.configuration.KeyspaceConfiguration
+import com.datastax.driver.core.ConsistencyLevel
 import io.kotlintest.matchers.be
 import io.kotlintest.specs.FreeSpec
 import java.util.*
@@ -37,6 +38,7 @@ class KeyspaceConfigurationSpec : FreeSpec() {
      */
     fun clearTestProperties() {
         System.clearProperty(ConfigurationProperty.KEYSPACE_NAME.namespace)
+        System.clearProperty(ConfigurationProperty.CONSISTENCY_LEVEL.namespace)
     }
 
     override fun beforeEach() {
@@ -60,6 +62,10 @@ class KeyspaceConfigurationSpec : FreeSpec() {
                     keyspaceConfig.name shouldBe null
                 }
 
+                "should have no consistency level as the default" {
+                    keyspaceConfig.consistency shouldBe null
+                }
+
                 "should have default cluster object" {
                     keyspaceConfig.clusterConfig should be a ClusterConfiguration::class
                 }
@@ -71,6 +77,11 @@ class KeyspaceConfigurationSpec : FreeSpec() {
                 "should allow keyspace name override" {
                     System.setProperty(ConfigurationProperty.KEYSPACE_NAME.namespace, "myspace")
                     KeyspaceConfiguration().name shouldBe "myspace"
+                }
+
+                "should allow consistency level override" {
+                    System.setProperty(ConfigurationProperty.CONSISTENCY_LEVEL.namespace, "QUORUM")
+                    KeyspaceConfiguration().consistency shouldBe ConsistencyLevel.QUORUM
                 }
 
             }


### PR DESCRIPTION
## Summary

Related tickets: #20 , #46 

ConsistencyLevel is now configurable via `cassandra.migration.keyspace.consistency` system property (in addition to setting `KeyspaceConfig.consistency` property).

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or [Wiki](https://github.com/builtamont-oss/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/builtamont-oss/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes
