### PR TITLE
Chore - Configurable CQL script read timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Options can be set either programmatically with API or via Java VM options.
 Migration:
  * `cassandra.migration.scripts.locations`: Locations of the migration scripts in CSV format. Scripts are scanned in the specified folder recursively. (default=`db/migration`)
  * `cassandra.migration.scripts.encoding`: The encoding of CQL scripts. (default=`UTF-8`)
+ * `cassandra.migration.scripts.timeout`: The read script timeout duration in seconds for CQL migrations. (default=`60`)
  * `cassandra.migration.scripts.allowoutoforder`: Allow out of order migration. (default=`false`)
  * `cassandra.migration.version.target`: The target version. Migrations with a higher version number will be ignored. (default=`latest`)
  * `cassandra.migration.table.prefix`: The prefix to be prepended to `cassandra_migration_version*` table names.

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/CassandraMigrationConfiguration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/CassandraMigrationConfiguration.kt
@@ -227,6 +227,16 @@ interface CassandraMigrationConfiguration {
     val locations: Array<String>
 
     /**
+     * Retrieves the per-host read timeout duration when executing CQL migration scripts.
+     *
+     * Set to `0` to disable timeout. Negative values are not allowed.
+     *
+     * @return The read timeout duration for the migration script execution in seconds.
+     *         (default: 60)
+     */
+    val timeout: Int
+
+    /**
      * Retrieves the migration table prefix.
      *
      * The prefix will be prepended to `cassandra_migration_version*` table names.
@@ -234,7 +244,7 @@ interface CassandraMigrationConfiguration {
      * By providing the prefix, multiple applications can have their own migration tables tracking the migration of their
      * own cassandra database assets without interfering with each other.
      *
-     * @return the prefix to be prepended to `cassandra_migration_version*` table names
+     * @return The prefix to be prepended to `cassandra_migration_version*` table names
      */
     val tablePrefix: String
 }

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/ConfigurationProperty.kt
@@ -38,9 +38,9 @@ enum class ConfigurationProperty(val namespace: String, val description: String)
             "Locations of the migration scripts in CSV format"
     ),
 
-    TABLE_PREFIX(
-            "cassandra.migration.table.prefix",
-            "Prefix to be prepended to cassandra_migration_version* table names"
+    SCRIPTS_TIMEOUT(
+            "cassandra.migration.scripts.timeout",
+            "CQL scripts timeout in seconds"
     ),
 
     ALLOW_OUT_OF_ORDER(
@@ -48,6 +48,15 @@ enum class ConfigurationProperty(val namespace: String, val description: String)
             "Allow out of order migration"
     ),
 
+    // Table configuration properties
+    // ~~~~~~
+    TABLE_PREFIX(
+            "cassandra.migration.table.prefix",
+            "Prefix to be prepended to cassandra_migration_version* table names"
+    ),
+
+    // Baseline version configuration properties
+    // ~~~~~~
     BASELINE_VERSION(
             "cassandra.migration.baseline.version",
             "Version to apply for an existing schema when baseline is run"

--- a/src/main/java/com/builtamont/cassandra/migration/internal/resolver/CompositeMigrationResolver.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/internal/resolver/CompositeMigrationResolver.kt
@@ -32,13 +32,15 @@ import java.util.*
  *
  * @param classLoader The ClassLoader for loading migrations on the classpath.
  * @param locations The locations where migrations are located.
- * @param encoding The encoding of Cql migrations.
+ * @param encoding The CQL migrations encoding.
+ * @param timeout The CQL migrations read timeout duration in seconds.
  * @param customMigrationResolvers Custom Migration Resolvers.
  */
 class CompositeMigrationResolver(
     classLoader: ClassLoader,
     locations: Locations,
     encoding: String,
+    timeout: Int,
     vararg customMigrationResolvers: MigrationResolver
 ) : MigrationResolver {
 
@@ -58,7 +60,7 @@ class CompositeMigrationResolver(
      */
     init {
         locations.getLocations().forEach {
-            migrationResolvers.add(CqlMigrationResolver(classLoader, it, encoding))
+            migrationResolvers.add(CqlMigrationResolver(classLoader, it, encoding, timeout))
             migrationResolvers.add(JavaMigrationResolver(classLoader, it))
         }
 

--- a/src/main/java/com/builtamont/cassandra/migration/internal/resolver/cql/CqlMigrationExecutor.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/internal/resolver/cql/CqlMigrationExecutor.kt
@@ -30,10 +30,12 @@ import com.datastax.driver.core.Session
  *                          The complete CQL script is not held as a member field here because this would use the total
  *                          size of all CQL migrations files in heap space during db migration.
  * @param encoding The encoding of this CQL migration.
-*/
+ * @param timeout The timout duration of this CQL migration.
+ */
 class CqlMigrationExecutor(
     private val cqlScriptResource: Resource,
-    private val encoding: String
+    private val encoding: String,
+    private val timeout: Int
 ) : MigrationExecutor {
 
     /**
@@ -42,7 +44,7 @@ class CqlMigrationExecutor(
      * @param session The Cassandra session connection to use to execute the migration.
      */
     override fun execute(session: Session) {
-        val cqlScript = CqlScript(cqlScriptResource, encoding)
+        val cqlScript = CqlScript(cqlScriptResource, encoding, timeout)
         cqlScript.execute(session)
     }
 

--- a/src/main/java/com/builtamont/cassandra/migration/internal/resolver/cql/CqlMigrationResolver.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/internal/resolver/cql/CqlMigrationResolver.kt
@@ -40,11 +40,13 @@ import java.util.zip.CRC32
  * @param classLoader The ClassLoader for loading migrations on the classpath.
  * @param location The location on the classpath where the migrations are located.
  * @param encoding The encoding of the .cql file.
+ * @param timeout The read script timeout duration in seconds.
  */
 class CqlMigrationResolver(
     classLoader: ClassLoader,
     private val location: Location,
-    private val encoding: String
+    private val encoding: String,
+    private val timeout: Int
 ) : MigrationResolver {
 
     /** The scanner to use. */
@@ -68,7 +70,7 @@ class CqlMigrationResolver(
         return resources.map { resource ->
             val resolvedMigration = extractMigrationInfo(resource)
             resolvedMigration.physicalLocation = resource.locationOnDisk
-            resolvedMigration.executor = CqlMigrationExecutor(resource, encoding)
+            resolvedMigration.executor = CqlMigrationExecutor(resource, encoding, timeout)
             resolvedMigration
         }.sortedWith(ResolvedMigrationComparator())
     }

--- a/src/test/java/com/builtamont/cassandra/migration/internal/resolver/CompositeMigrationResolverSpec.kt
+++ b/src/test/java/com/builtamont/cassandra/migration/internal/resolver/CompositeMigrationResolverSpec.kt
@@ -60,7 +60,8 @@ class CompositeMigrationResolverSpec : FreeSpec() {
                 val resolver = CompositeMigrationResolver(
                         Thread.currentThread().contextClassLoader,
                         Locations("migration/subdir/dir2", "migration.outoforder", "migration/subdir/dir1"),
-                        "UTF-8"
+                        "UTF-8",
+                        timeout = 0
                 )
                 val migrations = resolver.resolveMigrations()
 

--- a/src/test/java/com/builtamont/cassandra/migration/internal/resolver/cql/CqlMigrationResolverSpec.kt
+++ b/src/test/java/com/builtamont/cassandra/migration/internal/resolver/cql/CqlMigrationResolverSpec.kt
@@ -39,7 +39,8 @@ class CqlMigrationResolverSpec : FreeSpec() {
         return CqlMigrationResolver(
                 Thread.currentThread().contextClassLoader,
                 Location(location),
-                "UTF-8"
+                "UTF-8",
+                timeout = 0
         )
     }
 


### PR DESCRIPTION
## Summary

Completes chore #49 

Related tickets: #47 

Refactored CQL script read timeout as configurable system property.

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or [Wiki](https://github.com/builtamont-oss/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/builtamont-oss/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [ ] All tests passes
