### PR TITLE
Feature - User defined configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Import this library as a dependency:
 </repositories>
 ```
 
-***NOTE:** A Vagrant script is provided to enable quick integration testing against different or older Cassandra distributions.* 
+*NOTE: A Vagrant script is provided to enable quick integration testing against different or older Cassandra distributions.* 
 
 ### Migration version table
 
@@ -121,6 +121,13 @@ cm.migrate();
 
 #### Command line
 
+Logging level can be set by passing the following arguments:
+ * INFO: This is the default
+ * DEBUG: `-X`
+ * WARNING: `-q`
+ 
+##### With system properties JVM args
+
 ``` shell
 java -jar \
 -Dcassandra.migration.scripts.locations=filesystem:target/test-classes/migration/integ \
@@ -134,14 +141,18 @@ java -jar \
 target/*-jar-with-dependencies.jar migrate
 ```
 
-Logging level can be set by passing the following arguments:
- * INFO: This is the default
- * DEBUG: `-X`
- * WARNING: `-q`
+##### With application configuration file
+
+``` shell
+java -jar \
+-Dconfig.file=src/test/application.test.conf \
+target/*-jar-with-dependencies.jar migrate
+```
 
 ### VM Options
 
-Options can be set either programmatically with API or via Java VM options.
+Options can be set either programmatically with API, Java VM options, or configuration file.
+Refer to [Typesafe Config] library documentation or refer to [reference.conf] for a reference configuration.
 
 Migration:
  * `cassandra.migration.scripts.locations`: Locations of the migration scripts in CSV format. Scripts are scanned in the specified folder recursively. (default=`db/migration`)
@@ -200,7 +211,7 @@ Run `mvn test` to run the unit tests.
 
 Run `mvn verify` to run the integration tests.
 
-***NOTE:** The integration test might complain about some missing SIGAR binaries, this can be safely ignored. If you wish, you can download the missing binaries and set `java.library.path` parameter to point to the containing folder (e.g. `mvn verify -Djava.library.path=lib` where `lib` is the `/lib` folder relative to the project root).*
+*NOTE: The integration test might complain about some missing SIGAR binaries, this can be safely ignored. If you wish, you can download the missing binaries and set `java.library.path` parameter to point to the containing folder (e.g. `mvn verify -Djava.library.path=lib` where `lib` is the `/lib` folder relative to the project root).*
 
 ### Travis CI Integration Test Matrix
 
@@ -251,4 +262,6 @@ https://github.com/builtamont/cassandra-migration/releases
 [Flyway's project license page]: https://github.com/flyway/flyway/blob/master/LICENSE
 [fork-and-pull]: https://help.github.com/articles/using-pull-requests
 [LICENSE]: LICENSE
+[reference.conf]: https://github.com/builtamont-oss/cassandra-migration/blob/master/src/main/resources/reference.conf
 [SIGAR]: https://support.hyperic.com/display/SIGAR/Home
+[Typesafe Config]: https://github.com/typesafehub/config

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -92,6 +99,16 @@
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <version>3.0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.config4k</groupId>
+            <artifactId>config4k</artifactId>
+            <version>0.3.0</version>
         </dependency>
 
         <!-- Test-specific dependencies -->
@@ -263,6 +280,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>release</id>

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -18,5 +18,5 @@
 #   limitations under the License.
 ###
 
-mvn verify -Dconfig.file=src/test/resources/application.it-test.conf
+mvn verify -Dit.config.file=src/test/resources/application.it-test.conf
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -18,5 +18,5 @@
 #   limitations under the License.
 ###
 
-mvn verify -Dit.config.file=src/test/resources/application.it-test.conf
+mvn verify -Dit.config.file=src/test/resources/application.it-test.conf -Dcassandra.migration.disable_embedded=true
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -18,5 +18,9 @@
 #   limitations under the License.
 ###
 
-mvn verify -Dit.config.file=src/test/resources/application.it-test.conf -Dcassandra.migration.disable_embedded=true
+mvn verify \
+  -Dit.config.file=src/test/resources/application.it-test.conf \
+  -Dcassandra.migration.cluster.contactpoints=127.0.0.1 \
+  -Dcassandra.migration.cluster.port=9042 \
+  -Dcassandra.migration.disable_embedded=true
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -18,4 +18,5 @@
 #   limitations under the License.
 ###
 
-mvn verify -Dcassandra.migration.cluster.contactpoints=127.0.0.1 -Dcassandra.migration.cluster.port=9042 -Dcassandra.migration.disable_embedded=true
+mvn verify -Dconfig.file=src/test/resources/application.it-test.conf
+

--- a/src/main/java/com/builtamont/cassandra/migration/api/MigrationVersion.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/MigrationVersion.kt
@@ -221,9 +221,17 @@ class MigrationVersion : Comparable<MigrationVersion?> {
                 return "current".equals(version, ignoreCase = true)
             }
 
+            /**
+             * @return {@code true} if version is "LATEST".
+             */
+            fun isLatest(): Boolean {
+                return "latest".equals(version, ignoreCase = true)
+            }
+
             return when {
                 version == null           -> EMPTY
                 isCurrent()               -> CURRENT
+                isLatest()                -> LATEST
                 LATEST.version == version -> LATEST
                 else                      -> MigrationVersion(version)
             }

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/ClusterConfiguration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/ClusterConfiguration.kt
@@ -21,6 +21,8 @@ package com.builtamont.cassandra.migration.api.configuration
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import com.builtamont.cassandra.migration.internal.util.StringUtils
+import com.typesafe.config.ConfigFactory
+import io.github.config4k.extract
 
 /**
  * Cluster configuration.
@@ -81,29 +83,40 @@ class ClusterConfiguration {
      * ClusterConfiguration initialization.
      */
     init {
-        val contactpointsProp = System.getProperty(ConfigurationProperty.CONTACT_POINTS.namespace)
-        if (!contactpointsProp.isNullOrBlank()) this.contactpoints = StringUtils.tokenizeToStringArray(contactpointsProp, ",")
+        ConfigFactory.invalidateCaches()
+        ConfigFactory.load().let {
+            it.extract<String?>(ConfigurationProperty.CONTACT_POINTS.namespace)?.let {
+                this.contactpoints = StringUtils.tokenizeToStringArray(it, ",")
+            }
 
-        val portProp = System.getProperty(ConfigurationProperty.PORT.namespace)
-        if (!portProp.isNullOrBlank()) this.port = Integer.parseInt(portProp)
+            it.extract<Int?>(ConfigurationProperty.PORT.namespace)?.let {
+                this.port = it
+            }
 
-        val usernameProp = System.getProperty(ConfigurationProperty.USERNAME.namespace)
-        if (!usernameProp.isNullOrBlank()) this.username = usernameProp.trim()
+            it.extract<String?>(ConfigurationProperty.USERNAME.namespace)?.let {
+                this.username = it.trim()
+            }
 
-        val passwordProp = System.getProperty(ConfigurationProperty.PASSWORD.namespace)
-        if (!passwordProp.isNullOrBlank()) this.password = passwordProp.trim()
+            it.extract<String?>(ConfigurationProperty.PASSWORD.namespace)?.let {
+                this.password = it.trim()
+            }
 
-        val truststoreProp = System.getProperty(ConfigurationProperty.TRUSTSTORE.namespace)
-        if (!truststoreProp.isNullOrBlank()) this.truststore = Paths.get(truststoreProp.trim())
+            it.extract<String?>(ConfigurationProperty.TRUSTSTORE.namespace)?.let {
+                this.truststore = Paths.get(it.trim())
+            }
 
-        val truststorePasswordProp = System.getProperty(ConfigurationProperty.TRUSTSTORE_PASSWORD.namespace)
-        if (!truststorePasswordProp.isNullOrBlank()) this.truststorePassword = truststorePasswordProp.trim()
+            it.extract<String?>(ConfigurationProperty.TRUSTSTORE_PASSWORD.namespace)?.let {
+                this.truststorePassword = it.trim()
+            }
 
-        val keystoreProp = System.getProperty(ConfigurationProperty.KEYSTORE.namespace)
-        if (!keystoreProp.isNullOrBlank()) this.keystore = Paths.get(keystoreProp.trim())
+            it.extract<String?>(ConfigurationProperty.KEYSTORE.namespace)?.let {
+                this.keystore = Paths.get(it.trim())
+            }
 
-        val keystorePasswordProp = System.getProperty(ConfigurationProperty.KEYSTORE_PASSWORD.namespace)
-        if (!keystorePasswordProp.isNullOrBlank()) this.keystorePassword = keystorePasswordProp.trim()
+            it.extract<String?>(ConfigurationProperty.KEYSTORE_PASSWORD.namespace)?.let {
+                this.keystorePassword = it.trim()
+            }
+        }
     }
 
 }

--- a/src/main/java/com/builtamont/cassandra/migration/api/configuration/KeyspaceConfiguration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/api/configuration/KeyspaceConfiguration.kt
@@ -19,6 +19,8 @@
 package com.builtamont.cassandra.migration.api.configuration
 
 import com.datastax.driver.core.ConsistencyLevel
+import com.typesafe.config.ConfigFactory
+import io.github.config4k.extract
 
 /**
  * Keyspace configuration.
@@ -46,11 +48,16 @@ class KeyspaceConfiguration {
      * KeyspaceConfiguration initialization.
      */
     init {
-        val keyspaceProp = System.getProperty(ConfigurationProperty.KEYSPACE_NAME.namespace)
-        if (!keyspaceProp.isNullOrBlank()) this.name = keyspaceProp.trim()
+        ConfigFactory.invalidateCaches()
+        ConfigFactory.load().let {
+            it.extract<String?>(ConfigurationProperty.KEYSPACE_NAME.namespace)?.let {
+                this.name = it.trim()
+            }
 
-        val consistencyProp = System.getProperty(ConfigurationProperty.CONSISTENCY_LEVEL.namespace)
-        if (!consistencyProp.isNullOrBlank()) this.consistency = ConsistencyLevel.valueOf(consistencyProp.trim().toUpperCase())
+            it.extract<String?>(ConfigurationProperty.CONSISTENCY_LEVEL.namespace)?.let {
+                this.consistency = ConsistencyLevel.valueOf(it.trim().toUpperCase())
+            }
+        }
     }
 
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,88 @@
+###
+# File     : reference.conf
+# License  :
+#   Copyright (c) 2016 - 2017 Citadel Technology Solutions Pte Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+###
+
+cassandra.migration {
+
+  # Scripts configuration
+  # ~~~~~~
+  scripts {
+    # Encoding for CQL scripts
+    encoding = "UTF-8"
+
+    # Comma-separated values of migration files location(s)
+    locations = "db/migration"
+
+    # CQL scripts timeout in seconds
+    timeout = 60
+
+    # True to allow out-of-order migration
+    allowoutoforder = false
+  }
+
+  # Baseline migration configuratio
+  # ~~~~~~
+  baseline {
+    # Version to apply for an existing schema when baseline is run
+    version = "1"
+
+    # Description to apply to an existing schema when baseline is run
+    description = "<< Cassandra Baseline >>"
+  }
+
+  # The target version, migrations with a higher version number will be ignored
+  version.target = "LATEST"
+
+  # Cluster configuration
+  # ~~~~~~
+  cluster {
+    # Comma-separated values of node IP address(es)
+    contactpoints = "localhost"
+
+    # CQL native transport port
+    port = 9042
+
+    # Username for password authenticator
+    #username =
+
+    # Password for password authenticator
+    #password =
+
+    # Path to the truststore for client SSL
+    #truststore =
+
+    # Password for the truststrore
+    #truststore_password =
+
+    # Path to the keystore for client SSL certificate authentication
+    #keystore =
+
+    # Password for the keystore
+    #keystore_password =
+  }
+
+  # Keyspace configuration
+  # ~~~~~~
+  keyspace {
+    # Keyspace name
+    #name =
+
+    # Keyspace write consistency levels for migrations schema tracking
+    #consistency =
+  }
+
+}

--- a/src/test/java/com/builtamont/cassandra/migration/BaseKIT.kt
+++ b/src/test/java/com/builtamont/cassandra/migration/BaseKIT.kt
@@ -18,10 +18,13 @@
  */
 package com.builtamont.cassandra.migration
 
+import com.builtamont.cassandra.migration.api.configuration.ConfigurationProperty
 import com.builtamont.cassandra.migration.api.configuration.KeyspaceConfiguration
 import com.datastax.driver.core.Cluster
 import com.datastax.driver.core.Session
 import com.datastax.driver.core.SimpleStatement
+import com.typesafe.config.ConfigFactory
+import io.github.config4k.extract
 import io.kotlintest.specs.FreeSpec
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 
@@ -30,45 +33,33 @@ import org.cassandraunit.utils.EmbeddedCassandraServerHelper
  */
 open class BaseKIT : FreeSpec() {
 
+    /** Configuration reader instance */
+    private val conf = ConfigFactory.load()
+
     /** Keyspace name from configuration */
     val CASSANDRA_KEYSPACE: String =
-        if (System.getProperty("cassandra.migration.keyspace.name") != null) {
-            System.getProperty("cassandra.migration.keyspace.name")
-        } else {
-            "cassandra_migration_test"
-        }
+            conf.extract<String?>(ConfigurationProperty.KEYSPACE_NAME.namespace)
+                ?: "cassandra_migration_test"
 
     /** Cluster contact point(s) from configuration */
     val CASSANDRA_CONTACT_POINT: String =
-        if (System.getProperty("cassandra.migration.cluster.contactpoints") != null) {
-            System.getProperty("cassandra.migration.cluster.contactpoints")
-        } else {
-            "localhost"
-        }
+            conf.extract<String?>(ConfigurationProperty.CONTACT_POINTS.namespace)
+                ?: "localhost"
 
     /** Cluster connection port from configuration */
     val CASSANDRA_PORT: Int =
-        if (System.getProperty("cassandra.migration.cluster.port") != null) {
-            Integer.parseInt(System.getProperty("cassandra.migration.cluster.port"))
-        } else {
-            9147
-        }
+            conf.extract<Int?>(ConfigurationProperty.PORT.namespace)
+                ?: 9147
 
     /** Cluster credentials username */
     val CASSANDRA_USERNAME: String =
-        if (System.getProperty("cassandra.migration.cluster.username") != null) {
-            System.getProperty("cassandra.migration.cluster.username")
-        } else {
-            "cassandra"
-        }
+            conf.extract<String?>(ConfigurationProperty.USERNAME.namespace)
+                ?: "cassandra"
 
     /** Cluster credentials password */
     val CASSANDRA_PASSWORD: String =
-        if (System.getProperty("cassandra.migration.cluster.password") != null) {
-            System.getProperty("cassandra.migration.cluster.password")
-        } else {
-            "cassandra"
-        }
+            conf.extract<String?>(ConfigurationProperty.PASSWORD.namespace)
+                ?: "cassandra"
 
     /**
      * Flag to disable embedded Cassandra.
@@ -76,8 +67,8 @@ open class BaseKIT : FreeSpec() {
      * Used when running integration tests against DSE Community or Apache Cassandra instances.
      */
     val DISABLE_EMBEDDED: Boolean =
-        System.getProperty("cassandra.migration.disable_embedded") != null &&
-                java.lang.Boolean.parseBoolean(System.getProperty("cassandra.migration.disable_embedded"))
+            conf.extract<Boolean?>("cassandra.migration.disable_embedded")
+                ?: false
 
     /** Cluster connection session */
     private var session: Session? = null

--- a/src/test/java/com/builtamont/cassandra/migration/CassandraMigrationCommandLineKIT.kt
+++ b/src/test/java/com/builtamont/cassandra/migration/CassandraMigrationCommandLineKIT.kt
@@ -98,8 +98,10 @@ class CassandraMigrationCommandLineKIT : BaseKIT() {
             }
 
             "should run successfully provided HOCON configuration file" {
-                // NOTE: Workaround for Travis CI, config file location as passed-in args
-                val file = System.getProperty("config.file") ?: "src/test/resources/application.test.conf"
+                // NOTE: Workaround for Travis CI, config file location as passed-in args:
+                //       - Typical `mvn test` / `mvn integration-test` / `mvn verify` will use `appliation.test.conf` config
+                //       - In Travis CI, it will use `application.it-test.conf` for this test only
+                val file = System.getProperty("it.config.file") ?: "src/test/resources/application.test.conf"
                 val shell =
                         """java -jar
                          | -Dconfig.file=${file}

--- a/src/test/java/com/builtamont/cassandra/migration/CassandraMigrationCommandLineKIT.kt
+++ b/src/test/java/com/builtamont/cassandra/migration/CassandraMigrationCommandLineKIT.kt
@@ -98,9 +98,11 @@ class CassandraMigrationCommandLineKIT : BaseKIT() {
             }
 
             "should run successfully provided HOCON configuration file" {
+                // NOTE: Workaround for Travis CI, config file location as passed-in args
+                val file = System.getProperty("config.file") ?: "src/test/resources/application.test.conf"
                 val shell =
                         """java -jar
-                         | -Dconfig.file=src/test/resources/application.test.conf
+                         | -Dconfig.file=${file}
                          | target/*-jar-with-dependencies.jar
                          | migrate
                         """.trimMargin().replace("\n", "").replace("  ", " ")

--- a/src/test/java/com/builtamont/cassandra/migration/CassandraMigrationCommandLineKIT.kt
+++ b/src/test/java/com/builtamont/cassandra/migration/CassandraMigrationCommandLineKIT.kt
@@ -99,7 +99,7 @@ class CassandraMigrationCommandLineKIT : BaseKIT() {
 
             "should run successfully provided HOCON configuration file" {
                 // NOTE: Workaround for Travis CI, config file location as passed-in args:
-                //       - Typical `mvn test` / `mvn integration-test` / `mvn verify` will use `appliation.test.conf` config
+                //       - Typical `mvn test` / `mvn integration-test` / `mvn verify` will use `application.test.conf` config
                 //       - In Travis CI, it will use `application.it-test.conf` for this test only
                 val file = System.getProperty("it.config.file") ?: "src/test/resources/application.test.conf"
                 val shell =

--- a/src/test/resources/application.it-test.conf
+++ b/src/test/resources/application.it-test.conf
@@ -1,0 +1,94 @@
+###
+# File     : application.it-test.conf
+# License  :
+#   Copyright (c) 2016 - 2017 Citadel Technology Solutions Pte Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Note    :
+#   Special Integration Test config for Travis CI
+###
+
+cassandra.migration {
+
+  # Disable Embedded Cassandra for Travis CI tests against Apache Cassandra and DataStax Enterprise distribution
+  disable_embedded = true
+
+  # Scripts configuration
+  # ~~~~~~
+  scripts {
+    # Encoding for CQL scripts
+    encoding = "UTF-8"
+
+    # Comma-separated values of migration files location(s)
+    locations = "filesystem:target/test-classes/migration/integ"
+
+    # CQL scripts timeout in seconds
+    timeout = 60
+
+    # True to allow out-of-order migration
+    allowoutoforder = false
+  }
+
+  # Baseline migration configuratio
+  # ~~~~~~
+  baseline {
+    # Version to apply for an existing schema when baseline is run
+    version = "1"
+
+    # Description to apply to an existing schema when baseline is run
+    description = "<< Cassandra Baseline >>"
+  }
+
+  # The target version, migrations with a higher version number will be ignored
+  version.target = "LATEST"
+
+  # Cluster configuration
+  # ~~~~~~
+  cluster {
+    # Comma-separated values of node IP address(es)
+    contactpoints = "127.0.0.1"
+
+    # CQL native transport port
+    port = 9042
+
+    # Username for password authenticator
+    #username = "cassandra"
+
+    # Password for password authenticator
+    #password = "cassandra"
+
+    # Path to the truststore for client SSL
+    #truststore =
+
+    # Password for the truststrore
+    #truststore_password =
+
+    # Path to the keystore for client SSL certificate authentication
+    #keystore =
+
+    # Password for the keystore
+    #keystore_password =
+  }
+
+  # Keyspace configuration
+  # ~~~~~~
+  keyspace {
+    # Keyspace name
+    #name = "cassandra_migration_test"
+
+    # Keyspace write consistency levels for migrations schema tracking
+    #consistency =
+  }
+
+}

--- a/src/test/resources/application.it-test.conf
+++ b/src/test/resources/application.it-test.conf
@@ -63,10 +63,10 @@ cassandra.migration {
     port = 9042
 
     # Username for password authenticator
-    #username = "cassandra"
+    username = "cassandra"
 
     # Password for password authenticator
-    #password = "cassandra"
+    password = "cassandra"
 
     # Path to the truststore for client SSL
     #truststore =
@@ -85,7 +85,7 @@ cassandra.migration {
   # ~~~~~~
   keyspace {
     # Keyspace name
-    #name = "cassandra_migration_test"
+    name = "cassandra_migration_test"
 
     # Keyspace write consistency levels for migrations schema tracking
     #consistency =

--- a/src/test/resources/application.test.conf
+++ b/src/test/resources/application.test.conf
@@ -1,0 +1,88 @@
+###
+# File     : application.test.conf
+# License  :
+#   Copyright (c) 2016 - 2017 Citadel Technology Solutions Pte Ltd
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+###
+
+cassandra.migration {
+
+  # Scripts configuration
+  # ~~~~~~
+  scripts {
+    # Encoding for CQL scripts
+    encoding = "UTF-8"
+
+    # Comma-separated values of migration files location(s)
+    locations = "filesystem:target/test-classes/migration/integ"
+
+    # CQL scripts timeout in seconds
+    timeout = 60
+
+    # True to allow out-of-order migration
+    allowoutoforder = false
+  }
+
+  # Baseline migration configuratio
+  # ~~~~~~
+  baseline {
+    # Version to apply for an existing schema when baseline is run
+    version = "1"
+
+    # Description to apply to an existing schema when baseline is run
+    description = "<< Cassandra Baseline >>"
+  }
+
+  # The target version, migrations with a higher version number will be ignored
+  version.target = "LATEST"
+
+  # Cluster configuration
+  # ~~~~~~
+  cluster {
+    # Comma-separated values of node IP address(es)
+    contactpoints = "localhost"
+
+    # CQL native transport port
+    port = 9147
+
+    # Username for password authenticator
+    username = "cassandra"
+
+    # Password for password authenticator
+    password = "cassandra"
+
+    # Path to the truststore for client SSL
+    #truststore =
+
+    # Password for the truststrore
+    #truststore_password =
+
+    # Path to the keystore for client SSL certificate authentication
+    #keystore =
+
+    # Password for the keystore
+    #keystore_password =
+  }
+
+  # Keyspace configuration
+  # ~~~~~~
+  keyspace {
+    # Keyspace name
+    name = "cassandra_migration_test"
+
+    # Keyspace write consistency levels for migrations schema tracking
+    #consistency =
+  }
+
+}


### PR DESCRIPTION
## Summary

Completes feature #33 

Added support for reading config through application configuration file in addition to system properties. Leverages Typesafe Config library.

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or [Wiki](https://github.com/builtamont-oss/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/builtamont-oss/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [ ] All tests passes
