### PR TITLE
Chore - Update Apache Cassandra installation script to version `3.10`

### DIFF
--- a/scripts/configure-apache-cassandra.sh
+++ b/scripts/configure-apache-cassandra.sh
@@ -19,6 +19,6 @@
 ###
 
 sudo rm -rf /var/lib/cassandra/*
-wget http://www.us.apache.org/dist/cassandra/3.9/apache-cassandra-3.9-bin.tar.gz
-tar -xvzf apache-cassandra-3.9-bin.tar.gz
-sudo sh apache-cassandra-3.9/bin/cassandra -R
+wget http://www.us.apache.org/dist/cassandra/3.10/apache-cassandra-3.10-bin.tar.gz
+tar -xvzf apache-cassandra-3.10-bin.tar.gz
+sudo sh apache-cassandra-3.10/bin/cassandra -R


### PR DESCRIPTION
## Summary

Completes chore #62 

Update Apache Cassandra installation script to use version `3.10` since version `3.9` is no longer available from the download and mirror sites.

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or [Wiki](https://github.com/builtamont-oss/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/builtamont-oss/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes
