### PR TITLE
Avoid exception if keyspace does not exist

### DIFF
--- a/src/main/java/com/builtamont/cassandra/migration/CassandraMigration.kt
+++ b/src/main/java/com/builtamont/cassandra/migration/CassandraMigration.kt
@@ -340,7 +340,7 @@ class CassandraMigration : CassandraMigrationConfiguration {
 
                 // Connect to the specific Keyspace context (if already defined)
                 val keyspaces = cluster.metadata.keyspaces.map { it.name }
-                val keyspaceExists = keyspaces.first { it.equals(keyspaceConfig.name, ignoreCase = true) }.isNotEmpty()
+                val keyspaceExists = keyspaces.filter { it.equals(keyspaceConfig.name, ignoreCase = true) }.isNotEmpty()
                 if (keyspaceExists) {
                     session = cluster.connect(keyspaceConfig.name)
                 } else {


### PR DESCRIPTION
## Summary

I've replace ```keyspaces.first``` with ```keyspaces.filter```. At the moment ```keyspaces.first``` will throw a ```NoSuchElementException```. With ```keyspaces.filter``` the full statement will return ```false``` and a ```CassandraMigrationException``` will be thrown.

Stack trace before:
```
Exception in thread "main" java.util.NoSuchElementException: Collection contains no element matching the predicate.
  at com.builtamont.cassandra.migration.CassandraMigration.execute$cassandra_migration(CassandraMigration.kt:535)
  at com.builtamont.cassandra.migration.CassandraMigration.execute$cassandra_migration$default(CassandraMigration.kt:263)
  at com.builtamont.cassandra.migration.CassandraMigration.migrate(CassandraMigration.kt:168)
  at com.builtamont.cassandra.migration.CommandLine.main(CommandLine.kt:68)
```

Stack trace after:
```
Exception in thread "main" com.builtamont.cassandra.migration.api.CassandraMigrationException: Keyspace: cassandra_migration_test does not exist.
  at com.builtamont.cassandra.migration.CassandraMigration.execute$cassandra_migration(CassandraMigration.kt:347)
  at com.builtamont.cassandra.migration.CassandraMigration.execute$cassandra_migration$default(CassandraMigration.kt:263)
  at com.builtamont.cassandra.migration.CassandraMigration.migrate(CassandraMigration.kt:168)
  at com.builtamont.cassandra.migration.CommandLine.main(CommandLine.kt:68)
```

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or [Wiki](https://github.com/builtamont-oss/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/builtamont-oss/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes
