### PR TITLE
Chore - Fix Travis CI Cassandra and JDK version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,18 @@ env:
 matrix:
   include:
     - jdk: openjdk7
+      sudo: required
+      dist: trusty
       services: cassandra
       script: ./scripts/verify.sh
     - jdk: oraclejdk7
+      sudo: required
+      dist: trusty
       services: cassandra
       script: ./scripts/verify.sh
     - jdk: oraclejdk8
+      sudo: required
+      dist: trusty
       services: cassandra
       script: ./scripts/verify.sh
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ matrix:
       dist: trusty
       services: cassandra
       script: ./scripts/verify.sh
-    - jdk: oraclejdk7
-      sudo: required
-      dist: trusty
-      services: cassandra
-      script: ./scripts/verify.sh
     - jdk: oraclejdk8
       sudo: required
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ env:
     - secure: "04af3/9b67O5xd1U8GDhCqRQedHM3RP5HokdsOwAe8vN3EyyyKWXQafBkKsPvmDh5Uu/CYQppOYS4pQxB9ikweTfj34DbyyxpqJmjYE4KFvdQuFd0msyXhLCg6xfvS4KO6zjUQ8/c3rNQap4hx/icQ50/NES4rkUkxIZ/VKQ4jPXcBzPegEC6Le50Vw2tR8FT4erdNuABnGf1WnWGUUa3i6xdQQPyw8kdTIun08HxE6M9F+JJRH8jH3b7KizQhGdACAk4fnCOmFSgu7pm6ACXRJYqAfg055i5mr77yZXfeUIcIY3l45uY1uR8sxEbLUE/KwwlLGLVZWDI4xU6JIGisbrmMce+vz6YKUT9gHF3iAEJ5e4N18nJcRyHVrqcuRzv5Py0rFPZ70dr7aW/tk0JrTz6+FZ4FNIOdvIQe4qWy2TVns0EkERdtYGTdsigWfa/sKF/P5+/2foUOlnR06p55NHpIjaHRKy/XFVV1gyURUlRUGExVoIMX21bAMxGYMFMH7LfddRsly028lXwibRMkQGBeyVRYKQmqJvN3mTPbuAWmZZdaVpqn1jkgETlT6/qz43zv9y8jAOzZ22SeHEXe3NiexChqkAJWIH3cBYshMhy8H1fmYAIVYHvI+BPsbi+qDYSnAlAUDqoLWXPAvWUX89dAIXYRNcKplzpFsjWvM="
 matrix:
   include:
+# NOTE: Always fails in recent builds (host cannot be reached). Possibly because OpenJDK 7 is no longer supported by
+#       recent releases of Apache Cassandra (3.11.x), and this is reflected in the recent releases of DSE Community
+#       (i.e. also not compatible).
 #    - jdk: openjdk7
 #      sudo: required
 #      dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ env:
     - secure: "04af3/9b67O5xd1U8GDhCqRQedHM3RP5HokdsOwAe8vN3EyyyKWXQafBkKsPvmDh5Uu/CYQppOYS4pQxB9ikweTfj34DbyyxpqJmjYE4KFvdQuFd0msyXhLCg6xfvS4KO6zjUQ8/c3rNQap4hx/icQ50/NES4rkUkxIZ/VKQ4jPXcBzPegEC6Le50Vw2tR8FT4erdNuABnGf1WnWGUUa3i6xdQQPyw8kdTIun08HxE6M9F+JJRH8jH3b7KizQhGdACAk4fnCOmFSgu7pm6ACXRJYqAfg055i5mr77yZXfeUIcIY3l45uY1uR8sxEbLUE/KwwlLGLVZWDI4xU6JIGisbrmMce+vz6YKUT9gHF3iAEJ5e4N18nJcRyHVrqcuRzv5Py0rFPZ70dr7aW/tk0JrTz6+FZ4FNIOdvIQe4qWy2TVns0EkERdtYGTdsigWfa/sKF/P5+/2foUOlnR06p55NHpIjaHRKy/XFVV1gyURUlRUGExVoIMX21bAMxGYMFMH7LfddRsly028lXwibRMkQGBeyVRYKQmqJvN3mTPbuAWmZZdaVpqn1jkgETlT6/qz43zv9y8jAOzZ22SeHEXe3NiexChqkAJWIH3cBYshMhy8H1fmYAIVYHvI+BPsbi+qDYSnAlAUDqoLWXPAvWUX89dAIXYRNcKplzpFsjWvM="
 matrix:
   include:
-    - jdk: openjdk7
-      sudo: required
-      dist: trusty
-      services: cassandra
-      script: ./scripts/verify.sh
+#    - jdk: openjdk7
+#      sudo: required
+#      dist: trusty
+#      services: cassandra
+#      script: ./scripts/verify.sh
     - jdk: oraclejdk8
       sudo: required
       dist: trusty

--- a/scripts/configure-apache-cassandra.sh
+++ b/scripts/configure-apache-cassandra.sh
@@ -18,7 +18,9 @@
 #   limitations under the License.
 ###
 
+export CASS_VER=3.11.1
+
 sudo rm -rf /var/lib/cassandra/*
-wget http://www.us.apache.org/dist/cassandra/3.10/apache-cassandra-3.10-bin.tar.gz
-tar -xvzf apache-cassandra-3.10-bin.tar.gz
-sudo sh apache-cassandra-3.10/bin/cassandra -R
+wget http://www.us.apache.org/dist/cassandra/${CASS_VER}/apache-cassandra-${CASS_VER}-bin.tar.gz
+tar -xvzf apache-cassandra-${CASS_VER}-bin.tar.gz
+sudo sh apache-cassandra-${CASS_VER}/bin/cassandra -R


### PR DESCRIPTION
## Summary

Related tickets: #66 

Fixes Travis CI build issues, due to several causes:
* Switch to Travis' non-Docker base image, otherwise DSE Community won't run.
* Remove Oracle JDK 7 test, as it is no longer supported.
* Disable OpenJDK 7 test, it seems latest DSE Community will only run under Java 8 or later.

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or [Wiki](https://github.com/builtamont-oss/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/builtamont-oss/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes
