### PR TITLE
Remove Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
         <cassandra-unit.version>3.3.0.2</cassandra-unit.version>
         <commons-logging.version>1.2</commons-logging.version>
         <config4k.version>0.3.0</config4k.version> <!-- Last version to support Kotlin 1.x -->
-        <guava.version>19.0</guava.version> <!-- Compatibility issues with Guava v20 -->
         <hamcrest-junit.version>2.0.0.0</hamcrest-junit.version>
         <junit.version>4.12</junit.version>
         <kotlin.version>1.0.7</kotlin.version>
@@ -117,11 +116,6 @@
             <groupId>io.github.config4k</groupId>
             <artifactId>config4k</artifactId>
             <version>${config4k.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <!-- Test-specific dependencies -->

--- a/scripts/configure-apache-cassandra.sh
+++ b/scripts/configure-apache-cassandra.sh
@@ -18,9 +18,13 @@
 #   limitations under the License.
 ###
 
-export CASS_VER=3.11.1
+set -euo pipefail
+
+export CASS_VER="3.11.4"
 
 sudo rm -rf /var/lib/cassandra/*
-wget http://www.us.apache.org/dist/cassandra/${CASS_VER}/apache-cassandra-${CASS_VER}-bin.tar.gz
-tar -xvzf apache-cassandra-${CASS_VER}-bin.tar.gz
-sudo sh apache-cassandra-${CASS_VER}/bin/cassandra -R
+wget --content-disposition "https://www.apache.org/dyn/closer.lua?action=download&filename=/cassandra/${CASS_VER}/apache-cassandra-${CASS_VER}-bin.tar.gz"
+wget "http://www.apache.org/dist/cassandra/${CASS_VER}/apache-cassandra-${CASS_VER}-bin.tar.gz.sha256"
+sha256sum "apache-cassandra-${CASS_VER}-bin.tar.gz"
+tar -xvzf "apache-cassandra-${CASS_VER}-bin.tar.gz"
+sudo sh "apache-cassandra-${CASS_VER}/bin/cassandra" -R


### PR DESCRIPTION
It is unused and forces consumers to deal with compatibility concerns.

## Summary

Removes Guava as a dependency.

## Pull Request (PR) Checklist

### Documentation

- [x] Documentation in `README.md` or [Wiki](https://github.com/hhandoko/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/hhandoko/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review

- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes - (`./mvn verify`)
