### PR TITLE
Feature - SSL with default settings

### DIFF
--- a/src/main/java/com/hhandoko/cassandra/migration/CassandraMigration.kt
+++ b/src/main/java/com/hhandoko/cassandra/migration/CassandraMigration.kt
@@ -297,7 +297,7 @@ class CassandraMigration : CassandraMigrationConfiguration {
                 }
 
                 // Add SSL options to cluster builder
-                if (keyspaceConfig.clusterConfig.truststore != null) {
+                if (keyspaceConfig.clusterConfig.enableSsl && keyspaceConfig.clusterConfig.truststore != null) {
                     FileInputStream(keyspaceConfig.clusterConfig.truststore?.toFile()).use {
 
                         val sslCtxBuilder = SslContextBuilder.forClient()
@@ -328,8 +328,9 @@ class CassandraMigration : CassandraMigrationConfiguration {
                         }
                         builder.withSSL(NettySSLOptions(sslCtxBuilder.build()))
                     }
+                } else if (keyspaceConfig.clusterConfig.enableSsl) {
+                    builder.withSSL()
                 }
-
 
                 cluster = builder.build()
 

--- a/src/main/java/com/hhandoko/cassandra/migration/api/configuration/ClusterConfiguration.kt
+++ b/src/main/java/com/hhandoko/cassandra/migration/api/configuration/ClusterConfiguration.kt
@@ -56,6 +56,12 @@ class ClusterConfiguration {
       get set
 
     /**
+     * True to enable SSL.
+     */
+    var enableSsl = false
+      get set
+
+    /**
      * The path to the truststore.
      */
     var truststore: Path? = null
@@ -99,6 +105,10 @@ class ClusterConfiguration {
 
             it.extract<String?>(ConfigurationProperty.PASSWORD.namespace)?.let {
                 this.password = it.trim()
+            }
+
+            it.extract<Boolean?>(ConfigurationProperty.ENABLE_SSL.namespace)?.let {
+                this.enableSsl = it
             }
 
             it.extract<String?>(ConfigurationProperty.TRUSTSTORE.namespace)?.let {

--- a/src/main/java/com/hhandoko/cassandra/migration/api/configuration/ConfigurationProperty.kt
+++ b/src/main/java/com/hhandoko/cassandra/migration/api/configuration/ConfigurationProperty.kt
@@ -96,6 +96,11 @@ enum class ConfigurationProperty(val namespace: String, val description: String)
             "Password for password authenticator"
     ),
 
+    ENABLE_SSL(
+            "cassandra.migration.cluster.enablessl",
+            "Enable SSL"
+    ),
+
     TRUSTSTORE(
             "cassandra.migration.cluster.truststore",
             "Path to the truststore for client SSL"


### PR DESCRIPTION
## Summary

Add configuration flag to enable SSL. This configuration is useful in Azure App Services which currently does not support 128 and 256 bit encryption yet. The following allows a workaround to use SSL with its default settings.

<hr>

## Pull Request (PR) Checklist

### Documentation
- [x] Documentation in `README.md` or [Wiki](https://github.com/hhandoko/cassandra-migration/wiki) updated
- [x] Update [Release Notes](https://github.com/hhandoko/cassandra-migration/releases) if applicable -- collaborator-access only

### Code Review
- [x] Self code review -- take another pass through the changes yourself
- [x] Completed all relevant `TODO`s, or call them out in the PR comments

### Tests
- [x] All tests passes
