### PR TITLE
Added configuring enabled jmx/metrics options when building cluster

### DIFF
--- a/src/main/java/com/hhandoko/cassandra/migration/CassandraMigration.kt
+++ b/src/main/java/com/hhandoko/cassandra/migration/CassandraMigration.kt
@@ -296,6 +296,14 @@ class CassandraMigration : CassandraMigrationConfiguration {
                     }
                 }
 
+                if (!keyspaceConfig.clusterConfig.enableJmx) {
+                    builder.withoutJMXReporting()
+                }
+
+                if (!keyspaceConfig.clusterConfig.enableMetrics) {
+                    builder.withoutMetrics()
+                }
+
                 // Add SSL options to cluster builder
                 if (keyspaceConfig.clusterConfig.enableSsl && keyspaceConfig.clusterConfig.truststore != null) {
                     FileInputStream(keyspaceConfig.clusterConfig.truststore?.toFile()).use {

--- a/src/main/java/com/hhandoko/cassandra/migration/api/configuration/ClusterConfiguration.kt
+++ b/src/main/java/com/hhandoko/cassandra/migration/api/configuration/ClusterConfiguration.kt
@@ -62,6 +62,18 @@ class ClusterConfiguration {
       get set
 
     /**
+     * True to enable JMX reporting.
+     */
+    var enableJmx = true
+        get set
+
+    /**
+     * True to enable metrics.
+     */
+    var enableMetrics = true
+        get set
+
+    /**
      * The path to the truststore.
      */
     var truststore: Path? = null
@@ -109,6 +121,14 @@ class ClusterConfiguration {
 
             it.extract<Boolean?>(ConfigurationProperty.ENABLE_SSL.namespace)?.let {
                 this.enableSsl = it
+            }
+
+            it.extract<Boolean?>(ConfigurationProperty.ENABLE_JMX.namespace)?.let {
+                this.enableJmx = it
+            }
+
+            it.extract<Boolean?>(ConfigurationProperty.ENABLE_METRICS.namespace)?.let {
+                this.enableMetrics = it
             }
 
             it.extract<String?>(ConfigurationProperty.TRUSTSTORE.namespace)?.let {

--- a/src/main/java/com/hhandoko/cassandra/migration/api/configuration/ConfigurationProperty.kt
+++ b/src/main/java/com/hhandoko/cassandra/migration/api/configuration/ConfigurationProperty.kt
@@ -101,6 +101,16 @@ enum class ConfigurationProperty(val namespace: String, val description: String)
             "Enable SSL"
     ),
 
+    ENABLE_JMX(
+            "cassandra.migration.cluster.enablejmx",
+            "Enable JMX"
+    ),
+
+    ENABLE_METRICS(
+            "cassandra.migration.cluster.enablemetrics",
+            "Enable metrics"
+    ),
+
     TRUSTSTORE(
             "cassandra.migration.cluster.truststore",
             "Path to the truststore for client SSL"


### PR DESCRIPTION
## Summary

Added possibility to configure enabling jmx/metrics options when creating cluster object.
